### PR TITLE
 Configurable logger in ClientBuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 test:
-	phpunit .
+	phpunit tests
 
 push:
 	git push origin master

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,12 @@
     "require": {
         "php": ">=5.6"
     },
+    "require-dev": {
+        "psr/log": "^1.0.1"
+    },
+    "suggest": {
+        "psr/log": "^1.0.1"
+    },
     "autoload": {
         "psr-4": {
             "SmartyStreets\\PhpSdk\\": "src/"

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -44,13 +44,15 @@ class ClientBuilder {
             $maxRetries,
             $maxTimeout,
             $urlPrefix,
-            $proxy;
+            $proxy,
+            $logger;
 
     public function __construct(Credentials $signer = null) {
         $this->serializer = new NativeSerializer();
         $this->maxRetries = 5;
         $this->maxTimeout = 10000;
         $this->signer = $signer;
+        $this->logger = new MyLogger();
     }
 
     /**
@@ -117,6 +119,16 @@ class ClientBuilder {
         return $this;
     }
 
+    /**
+     * Set a logger instance to be used by the default Sender implementation.
+     * @param Logger $logger the new default logger
+     * @return $this Returns <b>this</b> to accommodate method chaining.
+     */
+    public function withDefaultLogger(Logger $logger) {
+        $this->logger = $logger;
+        return $this;
+    }
+
     public function buildUSAutocompleteApiClient() {
         $this->ensureURLPrefixNotNull(self::US_AUTOCOMPLETE_API_URL);
         return new USAutoCompleteApiClient($this->buildSender(), $this->serializer);
@@ -151,7 +163,7 @@ class ClientBuilder {
         $sender = new StatusCodeSender($sender);
 
         if ($this->maxRetries > 0)
-            $sender = new RetrySender($this->maxRetries, new MySleeper(), new MyLogger(), $sender);
+            $sender = new RetrySender($this->maxRetries, new MySleeper(), $this->logger, $sender);
 
         if ($this->signer != null)
             $sender = new SigningSender($this->signer, $sender);

--- a/src/Psr3Logger.php
+++ b/src/Psr3Logger.php
@@ -1,10 +1,25 @@
 <?php
 
-
 namespace SmartyStreets\PhpSdk;
 
+include_once('Logger.php');
 
-class Psr3Logger
+/**
+ * Log adapter for a PSR-3 compatible logging channel, such as Monolog.
+ *
+ * @package SmartyStreets\PhpSdk
+ */
+class Psr3Logger implements Logger
 {
+    private $logger;
 
+    function __construct(\Psr\Log\LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    function log($message)
+    {
+        $this->logger->info($message);
+    }
 }

--- a/src/Psr3Logger.php
+++ b/src/Psr3Logger.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace SmartyStreets\PhpSdk;
+
+
+class Psr3Logger
+{
+
+}

--- a/tests/International_Street/ClientTest.php
+++ b/tests/International_Street/ClientTest.php
@@ -2,12 +2,12 @@
 
 namespace SmartyStreets\PhpSdk\Tests\International_Street;
 
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSerializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockDeserializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/RequestCapturingSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockStatusCodeSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockCrashingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSerializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockDeserializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/RequestCapturingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockStatusCodeSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockCrashingSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/International_Street/Client.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/International_Street/Lookup.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/International_Street/Candidate.php');

--- a/tests/RetrySenderTest.php
+++ b/tests/RetrySenderTest.php
@@ -2,7 +2,7 @@
 
 namespace SmartyStreets\PhpSdk\Tests;
 
-require_once('Mocks/MockCrashingSender.php');
+require_once('mocks/MockCrashingSender.php');
 require_once('Mocks/MockLogger.php');
 require_once('Mocks/MockSleeper.php');
 require_once(dirname(dirname(__FILE__)) . '/src/RetrySender.php');

--- a/tests/SigningSenderTest.php
+++ b/tests/SigningSenderTest.php
@@ -2,7 +2,7 @@
 
 namespace SmartyStreets\PhpSdk\Tests;
 
-require_once('Mocks/MockSender.php');
+require_once('mocks/MockSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Response.php');
 require_once(dirname(dirname(__FILE__)) . '/src/StaticCredentials.php');

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -2,7 +2,7 @@
 
 namespace SmartyStreets\PhpSdk\Tests;
 
-require_once('Mocks/MockStatusCodeSender.php');
+require_once('mocks/MockStatusCodeSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/StatusCodeSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
 use SmartyStreets\PhpSdk\Tests\Mocks\MockStatusCodeSender;

--- a/tests/URLPrefixSenderTest.php
+++ b/tests/URLPrefixSenderTest.php
@@ -5,7 +5,7 @@ namespace SmartyStreets\PhpSdk\Tests;
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Response.php');
 require_once(dirname(dirname(__FILE__)) . '/src/URLPrefixSender.php');
-require_once('Mocks/MockSender.php');
+require_once('mocks/MockSender.php');
 use SmartyStreets\PhpSdk\Request;
 use SmartyStreets\PhpSdk\Response;
 use SmartyStreets\PhpSdk\URLPrefixSender;

--- a/tests/US_Autocomplete/ClientTest.php
+++ b/tests/US_Autocomplete/ClientTest.php
@@ -2,12 +2,12 @@
 
 namespace SmartyStreets\PhpSdk\Tests\US_Autocomplete;
 
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSerializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockDeserializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/RequestCapturingSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockStatusCodeSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockCrashingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSerializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockDeserializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/RequestCapturingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockStatusCodeSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockCrashingSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/URLPrefixSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Autocomplete/Result.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Autocomplete/Client.php');

--- a/tests/US_Extract/ClientTest.php
+++ b/tests/US_Extract/ClientTest.php
@@ -2,12 +2,12 @@
 
 namespace SmartyStreets\PhpSdk\Tests\US_Extract;
 
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSerializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockDeserializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/RequestCapturingSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockStatusCodeSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockCrashingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSerializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockDeserializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/RequestCapturingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockStatusCodeSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockCrashingSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/URLPrefixSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Extract/Result.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Extract/Client.php');

--- a/tests/us_street/ClientTest.php
+++ b/tests/us_street/ClientTest.php
@@ -2,10 +2,10 @@
 
 namespace SmartyStreets\PhpSdk\Tests\US_Street;
 
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSerializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockDeserializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/RequestCapturingSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSerializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockDeserializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/RequestCapturingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Street/Client.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Street/Lookup.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Street/Candidate.php');

--- a/tests/us_zipcode/ClientTest.php
+++ b/tests/us_zipcode/ClientTest.php
@@ -2,10 +2,10 @@
 
 namespace SmartyStreets\PhpSdk\Tests\US_ZIPCode;
 
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSerializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockDeserializer.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/RequestCapturingSender.php');
-require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSerializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockDeserializer.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/RequestCapturingSender.php');
+require_once(dirname(dirname(__FILE__)) . '/mocks/MockSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_ZIPCode/Client.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_ZIPCode/Lookup.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_ZIPCode/Result.php');


### PR DESCRIPTION
The default `Logger` instance can cause unexpected behavior for PHP web apps in that it writes to STDOUT; this will result in the logging messages becoming part of the HTML output.

This logging behavior can be avoided without too much hassle: the developer can manually create an instance of `RetrySender` and configure it on the builder. However, I'm proposing that the configuration of the logger be made part of the `ClientBuilder` interface. My reasoning behind this change is as follows: the `withSender` method is for more advanced customization of the operation of the client. One should not have to have an understanding of the implementation details just to install the appropriate logging.

Since nearly every PHP web framework includes a PSR-3 compatible logging solution, I've included an adapter class.