### PR TITLE
Avoid undefined constant notice (fixes #11)

### DIFF
--- a/src/NativeSender.php
+++ b/src/NativeSender.php
@@ -49,8 +49,8 @@ class NativeSender implements Sender {
         curl_setopt($ch, CURLOPT_HTTPHEADER, $this->setHeaders($smartyRequest));
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $this->maxTimeOut);
         curl_setopt($ch, CURLOPT_USERAGENT, 'smartystreets (sdk:php@' . VERSION . ')');
-        curl_setopt($ch, CURLINFO_HEADER_OUT, STDERR);
-
+        if ($this->debugMode && defined("STDERR"))
+            curl_setopt($ch, CURLINFO_HEADER_OUT, true);
         if ($this->proxy != null)
             $this->setProxy($ch);
 


### PR DESCRIPTION
This is a hotfix for #11 so it'll stop logging notices in non-CLI production environments. It could use some tests, but there's a good chance the approach will need to be modified for non-CLI environments that want to take advantage of the debug info.