### PR TITLE
Fix duplicate definition of GeolocateType constants

### DIFF
--- a/src/US_Autocomplete/GeolocateType.php
+++ b/src/US_Autocomplete/GeolocateType.php
@@ -2,9 +2,15 @@
 
 namespace SmartyStreets\PhpSdk\US_Autocomplete;
 
-define('GEOLOCATE_TYPE_CITY', 'city', false);
-define('GEOLOCATE_TYPE_STATE', 'state', false);
-define('GEOLOCATE_TYPE_NONE', null, false);
+if (! defined('GEOLOCATE_TYPE_CITY')) {
+    define('GEOLOCATE_TYPE_CITY', 'city', false);
+}
+if (! defined('GEOLOCATE_TYPE_STATE')) {
+    define('GEOLOCATE_TYPE_STATE', 'state', false);
+}
+if (! defined('GEOLOCATE_TYPE_NONE')) {
+    define('GEOLOCATE_TYPE_NONE', null, false);
+}
 
 /**
  * This field corresponds to the <b>geolocate</b> and <b>geolocate_precision</b> fields in the US Autocomplete API.

--- a/src/US_Autocomplete_Pro/GeolocateType.php
+++ b/src/US_Autocomplete_Pro/GeolocateType.php
@@ -2,8 +2,12 @@
 
 namespace SmartyStreets\PhpSdk\US_Autocomplete_Pro;
 
-define('GEOLOCATE_TYPE_CITY', 'city', false);
-define('GEOLOCATE_TYPE_NONE', null, false);
+if (! defined('GEOLOCATE_TYPE_CITY')) {
+    define('GEOLOCATE_TYPE_CITY', 'city', false);
+}
+if (! defined('GEOLOCATE_TYPE_NONE')) {
+    define('GEOLOCATE_TYPE_NONE', null, false);
+}
 
 /**
  * This field corresponds to the <b>prefer_geolocation</b> field in the US Autocomplete Pro API.


### PR DESCRIPTION
Since the recent release of this package that added the `US_Autocomplete_Pro` namespace I've been receiving error `ErrorException: Constant GEOLOCATE_TYPE_CITY already defined` when I instantiate a `SmartyStreets\PhpSdk\US_Street\Client` instance using the `SmartyStreets\PhpSdk\ClientBuilder` `buildUsStreetApiClient` function. 

This is due to the identical constants defined in `SmartyStreets\PhpSdk\US_Autocomplete\GeolocateType` and `SmartyStreets\PhpSdk\US_Autocomplete_Pro\GeolocateType`. 

This PR resolves this issue by adding checks to each of these classes to ensure the constants have not already been defined. 