### PR TITLE
Fix set autocomplete result limit bug

### DIFF
--- a/src/US_Autocomplete/Lookup.php
+++ b/src/US_Autocomplete/Lookup.php
@@ -111,7 +111,7 @@ class Lookup {
     }
 
     public function setMaxSuggestions($maxSuggestions) {
-        if ($maxSuggestions > 0 && $this->maxSuggestions <= 10)
+        if ($maxSuggestions > 0 && $maxSuggestions <= 10)
             $this->maxSuggestions = $maxSuggestions;
         else
             throw new \InvalidArgumentException("Max suggestions must be a positive integer no larger than 10.");

--- a/src/US_Autocomplete_Pro/Lookup.php
+++ b/src/US_Autocomplete_Pro/Lookup.php
@@ -163,7 +163,7 @@ class Lookup {
     }
 
     public function setMaxResults($maxResults) {
-        if ($maxResults > 0 && $this->maxResults <= 10)
+        if ($maxResults > 0 && $maxResults <= 10)
             $this->maxResults = $maxResults;
         else
             throw new \InvalidArgumentException("Max suggestions must be a positive integer no larger than 10.");

--- a/tests/US_Autocomplete/LookupTest.php
+++ b/tests/US_Autocomplete/LookupTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Tests\US_Autocomplete;
+
+use PHPUnit\Framework\TestCase;
+use SmartyStreets\PhpSdk\US_Autocomplete\Lookup;
+
+class LookupTest extends TestCase
+{
+    public function testSettingMaxSuggestionsLargerThanTenThrowsAnException()
+    {
+        $lookup = new Lookup();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Max suggestions must be a positive integer no larger than 10.');
+
+        $lookup->setMaxSuggestions(11);
+    }
+}

--- a/tests/US_Autocomplete_Pro/LookupTest.php
+++ b/tests/US_Autocomplete_Pro/LookupTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Tests\US_Autocomplete_Pro;
+
+use PHPUnit\Framework\TestCase;
+use SmartyStreets\PhpSdk\US_Autocomplete_Pro\Lookup;
+
+class LookupTest extends TestCase
+{
+    public function testSettingMaxResultsLargerThanTenThrowsAnException()
+    {
+        $lookup = new Lookup();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Max suggestions must be a positive integer no larger than 10.');
+
+        $lookup->setMaxResults(11);
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in the autocomplete lookup implementation. But it can lead to a breaking change if the limit is already set to  >10.