### PR TITLE
Fixed geolocation and zipcode functions

### DIFF
--- a/src/US_Autocomplete_Pro/Client.php
+++ b/src/US_Autocomplete_Pro/Client.php
@@ -53,7 +53,7 @@ class Client {
         $request->setParameter("prefer_states", $this->buildFilterString($lookup->getPreferStates()));
         $request->setParameter("prefer_zip_codes", $this->buildFilterString($lookup->getPreferZIPCodes()));
         $request->setParameter("prefer_ratio", $lookup->getPreferRatioStringIfSet());
-        $request->setParameter("prefer_geolocation", $lookup->getGeolocateType()->getName());
+        $request->setParameter("prefer_geolocation", $lookup->getPreferGeolocation()->getName());
         $request->setParameter("selected", $lookup->getSelected());
         $request->setParameter("source", $lookup->getSource());
 

--- a/src/US_Autocomplete_Pro/Lookup.php
+++ b/src/US_Autocomplete_Pro/Lookup.php
@@ -58,8 +58,8 @@ class Lookup {
     }
 
     public function addZIPFilter($zipcode) {
-        $this->geolocateType = new GeolocateType(GEOLOCATE_TYPE_NONE);
-        $this->zipFilter = $zipcode;
+        $this->preferGeolocation = new GeolocateType(GEOLOCATE_TYPE_NONE);
+        $this->zipFilter[] = $zipcode;
     }
 
     public function addStateExclusion($stateAbbreviation) {
@@ -75,8 +75,8 @@ class Lookup {
     }
 
     public function addPreferZIPCode($zipcode) {
-        $this->geolocateType = new GeolocateType(GEOLOCATE_TYPE_NONE);
-        $this->preferZIPCodes = $zipcode;
+        $this->preferGeolocation = new GeolocateType(GEOLOCATE_TYPE_NONE);
+        $this->preferZIPCodes[] = $zipcode;
     }
 
     //region [ Getters ]
@@ -129,7 +129,7 @@ class Lookup {
         return $this->preferRatio;
     }
 
-    public function getGeolocateType() {
+    public function getPreferGeolocation() {
         return $this->preferGeolocation;
     }
 
@@ -180,7 +180,7 @@ class Lookup {
     }
 
     public function setZIPFilter($zipFilter) {
-        $this->geolocateType =  new GeolocateType(GEOLOCATE_TYPE_NONE);
+        $this->preferGeolocation = new GeolocateType(GEOLOCATE_TYPE_NONE);
         $this->zipFilter = $zipFilter;
     }
 
@@ -193,16 +193,16 @@ class Lookup {
     }
 
     public function setPreferZIPCodes($zipcodes) {
-        $this->geolocateType = new GeolocateType(GEOLOCATE_TYPE_NONE);
-        $this->$this->preferZIPCodes = $zipcodes;
+        $this->preferGeolocation = new GeolocateType(GEOLOCATE_TYPE_NONE);
+        $this->preferZIPCodes = $zipcodes;
     }
 
     public function setPreferRatio($preferRatio) {
         $this->preferRatio = $preferRatio;
     }
 
-    public function setGeolocateType(GeolocateType $geolocateType) {
-        $this->geolocateType = $geolocateType;
+    public function setPreferGeolocation(GeolocateType $geolocateType) {
+        $this->preferGeolocation = $geolocateType;
     }
 
     public function setSelected($selected) {


### PR DESCRIPTION
Some of the functions in [src/US_Autocomplete_Pro/Lookup.php](https://github.com/smartystreets/smartystreets-php-sdk/blob/d55bf1a0e68c87de84cdae41a9c7d5976a092758/src/US_Autocomplete_Pro/Lookup.php) were using `geolocateType` instead of `preferGeolocation`. Also, `zipFilter` and `preferZIPCodes` were being set, rather than added to, by the `addZIPFilter` and `addPreferZIPCode` functions.

I'm guessing this was copied from [src/US_Autocomplete/Lookup.php](https://github.com/smartystreets/smartystreets-php-sdk/blob/d55bf1a0e68c87de84cdae41a9c7d5976a092758/src/US_Autocomplete/Lookup.php) and modified, but a few things were missed.