### PR TITLE
Fix PHP 8.2 Deprecation Warning

### DIFF
--- a/src/US_Street/Analysis.php
+++ b/src/US_Street/Analysis.php
@@ -13,6 +13,7 @@ class Analysis {
             $dpvFootnotes,
             $cmra,
             $vacant,
+            $noStat,
             $active,
             $isEwsMatch,
             $footnotes,


### PR DESCRIPTION
Fixes a dynamic property assignment that raises a deprecation warning in PHP 8.2 

```
Creation of dynamic property SmartyStreets\PhpSdk\US_Street\Analysis::$noStat is deprecated in /var/task/vendor/smartystreets/phpsdk/src/US_Street/Analysis.php:29
```

https://wiki.php.net/rfc/deprecate_dynamic_properties