### PR TITLE
Abbey/retrystatus

### DIFF
--- a/examples/InternationalAutocompleteExample.php
+++ b/examples/InternationalAutocompleteExample.php
@@ -36,11 +36,15 @@ class InternationalAutocompleteExample {
         $lookup->setCountry("FRA");
         $lookup->setLocality("Paris");
 
-        $client->sendLookup($lookup); // The candidates are also stored in the lookup's 'result' field.
-
-        foreach ($lookup->getResult() as $candidate) {
-            echo($candidate->getStreet() . " " . $candidate->getLocality() . " " . $candidate->getCountryISO3() . "\n");
-        };
+        try {
+            $client->sendLookup($lookup); // The candidates are also stored in the lookup's 'result' field.
+            foreach ($lookup->getResult() as $candidate) {
+                echo($candidate->getStreet() . " " . $candidate->getLocality() . " " . $candidate->getCountryISO3() . "\n");
+            };
+        }
+        catch (\Exception $ex) {
+            echo($ex->getMessage());
+        }
 
     }
 }

--- a/examples/InternationalExample.php
+++ b/examples/InternationalExample.php
@@ -43,8 +43,16 @@ class InternationalExample {
         $lookup->setCountry("Brazil");
         $lookup->setPostalCode("02516-050");
 
-        $client->sendLookup($lookup); // The candidates are also stored in the lookup's 'result' field.
+        try {
+            $client->sendLookup($lookup); // The candidates are also stored in the lookup's 'result' field.
+            $this->displayResults($lookup);
+        }
+        catch (\Exception $ex) {
+            echo($ex->getMessage());
+        }
+    }
 
+    public function displayResults(Lookup $lookup) {
         $firstCandidate = $lookup->getResult()[0];
 
         echo("Address is " . $firstCandidate->getAnalysis()->getVerificationStatus());

--- a/examples/USAutocompleteProExample.php
+++ b/examples/USAutocompleteProExample.php
@@ -40,25 +40,37 @@ class USAutocompleteProExample
         // https://smartystreets.com/docs/cloud/us-autocomplete-api
 
         $lookup = new Lookup("1042 W Center");
+        try {
+            $client->sendLookup($lookup);
+            $this->displayResultsNoFilter($lookup);
 
-        $client->sendLookup($lookup);
+            $lookup->addStateFilter("CO");
+            $lookup->addStateFilter("UT");
+            $lookup->addCityFilter("Denver");
+            $lookup->addCityFilter("Orem");
+//          $lookup->addPreferState("CO");
+            $lookup->setPreferRatio(3);
+            $lookup->setMaxResults(5);
+            $lookup->setSource("all");
 
+            $client->sendLookup($lookup);
+            $this->displayResultsFilter($lookup);
+        }
+        catch (\Exception $ex) {
+            echo($ex->getMessage());
+        }
+    }
+
+    private function displayResultsNoFilter(Lookup $lookup)
+    {
         echo("*** Result with no filter ***");
         echo("\n");
         foreach ($lookup->getResult() as $suggestion)
             $this->printResults($suggestion);
+    }
 
-        $lookup->addStateFilter("CO");
-        $lookup->addStateFilter("UT");
-        $lookup->addCityFilter("Denver");
-        $lookup->addCityFilter("Orem");
-//        $lookup->addPreferState("CO");
-        $lookup->setPreferRatio(3);
-        $lookup->setMaxResults(5);
-        $lookup->setSource("all");
-
-        $client->sendLookup($lookup);
-
+    private function displayResultsFilter(Lookup $lookup)
+    {
         echo("\n");
         echo("*** Result with some filters ***\n");
         foreach($lookup->getResult() as $suggestion)

--- a/examples/USExtractExample.php
+++ b/examples/USExtractExample.php
@@ -35,9 +35,17 @@ class USExtractExample {
         $lookup->isAggressive();
         $lookup->setAddressesHaveLineBreaks(false);
         $lookup->setAddressesPerLine(2);
+        try {
+            $client->sendLookup($lookup);
+            $this->displayResults($lookup);
+        }
+        catch (\Exception $ex) {
+            echo($ex->getMessage());
+        }
+    }
 
-        $client->sendLookup($lookup);
-
+    public function displayResults(Lookup $lookup)
+    {
         $result = $lookup->getResult();
         $metadata = $result->getMetadata();
         print('Found ' . $metadata->getAddressCount() . " addresses.\n");
@@ -46,7 +54,7 @@ class USExtractExample {
         $addresses = $result->getAddresses();
 
         print("Addresses: \n**********************\n");
-        foreach($addresses as $address) {
+        foreach ($addresses as $address) {
             print("\n\"" . $address->getText() . "\"\n");
             print("\nVerified? " . ArrayUtil::getStringValueOfBoolean($address->isVerified()));
             if (count($address->getCandidates()) > 0) {

--- a/examples/USReverseGeoExample.php
+++ b/examples/USReverseGeoExample.php
@@ -34,8 +34,17 @@ class USReverseGeoExample
 
         $lookup = new Lookup(40.111111, -111.111111);
 
-        $client->sendLookup($lookup); // The candidates are also stored in the lookup's 'result' field.
+        try {
+            $client->sendLookup($lookup);
+            $this->displayResults($lookup);
+        }
+        catch (Exception $ex) {
+            echo($ex->getMessage());
+        }
+    }
 
+    public function displayResults(Lookup $lookup)
+    {
         echo("Results for input: " . $lookup->getLatitude() . ", " . $lookup->getLongitude() . "\n");
 
         foreach ($lookup->getResponse()->getResults() as $result) {

--- a/examples/USStreetLookupsWithMatchStrategyExamples.php
+++ b/examples/USStreetLookupsWithMatchStrategyExamples.php
@@ -54,9 +54,6 @@ class USStreetLookupsWithMatchStrategyExamples {
         catch (BatchFullException $ex) {
             echo("Oops! Batch was already full.");
         }
-        catch (SmartyException $ex) {
-            echo($ex->getMessage());
-        }
         catch (\Exception $ex) {
             echo($ex->getMessage());
         }

--- a/examples/UsStreetMultipleAddressesExample.php
+++ b/examples/UsStreetMultipleAddressesExample.php
@@ -68,8 +68,6 @@ class UsStreetMultipleAddressesExample
             $this->displayResults($batch);
         } catch (BatchFullException $ex) {
             echo("Oops! Batch was already full.");
-        } catch (SmartyException $ex) {
-            echo($ex->getMessage());
         } catch (\Exception $ex) {
             echo($ex->getMessage());
         }

--- a/examples/UsStreetSingleAddressExample.php
+++ b/examples/UsStreetSingleAddressExample.php
@@ -52,9 +52,6 @@ class UsStreetSingleAddressExample {
             $client->sendLookup($lookup);
             $this->displayResults($lookup);
         }
-        catch (SmartyException $ex) {
-            echo($ex->getMessage());
-        }
         catch (Exception $ex) {
             echo($ex->getMessage());
         }

--- a/examples/UsZIPCodeMultipleLookupsExample.php
+++ b/examples/UsZIPCodeMultipleLookupsExample.php
@@ -54,9 +54,6 @@ class UsZIPCodeMultipleLookupsExample {
         catch (BatchFullException $ex) {
             echo("Oops! Batch was already full.");
         }
-        catch (SmartyException $ex) {
-            echo($ex->getMessage());
-        }
         catch (\Exception $ex) {
             echo($ex->getMessage());
         }

--- a/examples/UsZIPCodeSingleLookupExample.php
+++ b/examples/UsZIPCodeSingleLookupExample.php
@@ -38,9 +38,6 @@ class UsZIPCodeSingleLookupExample {
             $client->sendLookup($lookup);
             $this->displayResults($lookup);
         }
-        catch (SmartyException $ex) {
-            echo($ex->getMessage());
-        }
         catch (\Exception $ex) {
             echo($ex->getMessage());
         }

--- a/src/Exceptions/BadGatewayException.php
+++ b/src/Exceptions/BadGatewayException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Exceptions;
+require_once 'SmartyException.php';
+
+class BadGatewayException extends SmartyException {
+
+}

--- a/src/Exceptions/MustRetryException.php
+++ b/src/Exceptions/MustRetryException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Exceptions;
+require_once 'SmartyException.php';
+
+class MustRetryException extends SmartyException {
+
+}

--- a/src/Exceptions/RequestTimeoutException.php
+++ b/src/Exceptions/RequestTimeoutException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Exceptions;
+require_once 'SmartyException.php';
+
+class RequestTimeoutException extends SmartyException {
+
+}

--- a/src/Exceptions/SmartyException.php
+++ b/src/Exceptions/SmartyException.php
@@ -3,5 +3,8 @@
 namespace SmartyStreets\PhpSdk\Exceptions;
 
 class SmartyException extends \Exception {
+    public function __construct($message, $code = 0, Throwable $previous = null) {
 
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/RetrySender.php
+++ b/src/RetrySender.php
@@ -5,7 +5,12 @@ namespace SmartyStreets\PhpSdk;
 include_once('Sender.php');
 require_once('Exceptions/TooManyRequestsException.php');
 
+use SmartyStreets\PhpSdk\Exceptions\BadGatewayException;
+use SmartyStreets\PhpSdk\Exceptions\GatewayTimeoutException;
+use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
 use SmartyStreets\PhpSdk\Exceptions\MustRetryException;
+use SmartyStreets\PhpSdk\Exceptions\RequestTimeoutException;
+use SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException;
 use SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException;
 
 
@@ -46,7 +51,7 @@ class RetrySender implements Sender
         try {
             return $this->inner->send($request);
         } catch (\Exception $ex) {
-            if (($ex instanceof MustRetryException || $ex instanceof TooManyRequestsException || $ex instanceof InternalServerError || $ex instanceof ServiceUnavailableException || $ex instanceof GatewayTimeoutException || $ex instanceof RequestTimeoutException || $ex instanceof BadGatewayException) && $attempt < $this->maxRetries) {
+            if (($ex instanceof MustRetryException || $ex instanceof TooManyRequestsException || $ex instanceof InternalServerErrorException || $ex instanceof ServiceUnavailableException || $ex instanceof GatewayTimeoutException || $ex instanceof RequestTimeoutException || $ex instanceof BadGatewayException) && $attempt < $this->maxRetries) {
                 $this->backoff(self::MAX_BACKOFF_DURATION);
             } else {
                 throw $ex; 

--- a/src/RetrySender.php
+++ b/src/RetrySender.php
@@ -54,7 +54,8 @@ class RetrySender implements Sender
             if (($ex instanceof MustRetryException || $ex instanceof TooManyRequestsException || $ex instanceof InternalServerErrorException || $ex instanceof ServiceUnavailableException || $ex instanceof GatewayTimeoutException || $ex instanceof RequestTimeoutException || $ex instanceof BadGatewayException) && $attempt < $this->maxRetries) {
                 $this->backoff(self::MAX_BACKOFF_DURATION);
             } else {
-                throw $ex; 
+                echo $ex->getCode() . "\n";
+                throw $ex;
             }
         }
 

--- a/src/RetrySender.php
+++ b/src/RetrySender.php
@@ -50,8 +50,11 @@ class RetrySender implements Sender
     {
         try {
             return $this->inner->send($request);
+        } catch (TooManyRequestsException $ex) {
+            $this->backoff($ex->getHeader());
+            return null;
         } catch (\Exception $ex) {
-            if (($ex instanceof MustRetryException || $ex instanceof TooManyRequestsException || $ex instanceof InternalServerErrorException || $ex instanceof ServiceUnavailableException || $ex instanceof GatewayTimeoutException || $ex instanceof RequestTimeoutException || $ex instanceof BadGatewayException) && $attempt < $this->maxRetries) {
+            if (($ex instanceof MustRetryException || $ex instanceof InternalServerErrorException || $ex instanceof ServiceUnavailableException || $ex instanceof GatewayTimeoutException || $ex instanceof RequestTimeoutException || $ex instanceof BadGatewayException) && $attempt < $this->maxRetries) {
                 $this->backoff(self::MAX_BACKOFF_DURATION);
             } else {
                 echo $ex->getCode() . "\n";

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -49,7 +49,7 @@ class StatusCodeSender implements Sender
             case 402:
                 throw new PaymentRequiredException("Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.", $response->getStatusCode());
             case 408:
-                throw new RequestTimeoutException("Request timeout error.");
+                throw new RequestTimeoutException("Request timeout error.", $response->getStatusCode());
             case 413:
                 throw new RequestEntityTooLargeException("Request Entity Too Large: The request body has exceeded the maximum size.", $response->getStatusCode());
             case 422:
@@ -70,7 +70,7 @@ class StatusCodeSender implements Sender
             case 500:
                 throw new InternalServerErrorException("Internal Server Error.", $response->getStatusCode());
             case 502:
-                throw new BadGatewayException("Bad Gateway error.");
+                throw new BadGatewayException("Bad Gateway error.", $response->getStatusCode());
             case 503:
                 throw new ServiceUnavailableException("Service Unavailable. Try again later.", $response->getStatusCode());
             case 504:

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -14,10 +14,12 @@ require_once('Exceptions/UnprocessableEntityException.php');
 require_once('Exceptions/GatewayTimeoutException.php');
 
 use SmartyStreets\PhpSdk\Exceptions\BadCredentialsException;
+use SmartyStreets\PhpSdk\Exceptions\BadGatewayException;
 use SmartyStreets\PhpSdk\Exceptions\BadRequestException;
 use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
 use SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException;
 use SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException;
+use SmartyStreets\PhpSdk\Exceptions\RequestTimeoutException;
 use SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException;
 use SmartyStreets\PhpSdk\Exceptions\SmartyException;
 use SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException;
@@ -58,7 +60,7 @@ class StatusCodeSender implements Sender
                 if (! isset($responseJSON['errors'])) {
                     throw new TooManyRequestsException("The rate limit for the plan associated with this subscription has been exceeded. To see plans with higher rate limits, visit our pricing page." . $response->getStatusCode());
                 }
-
+                $errorMessage = '';
                 foreach($responseJSON['errors'] as $error){
                     $errorMessage .= isset($error['message']) ? $error['message'].' ': '';
                 }

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -46,6 +46,8 @@ class StatusCodeSender implements Sender
                 throw new BadCredentialsException("Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials." . $response->getStatusCode());
             case 402:
                 throw new PaymentRequiredException("Payment Required: There is no active subscription for the account associated with the credentials submitted with the request." . $response->getStatusCode());
+            case 408:
+                throw new RequestTimeoutException("Request timeout error.");
             case 413:
                 throw new RequestEntityTooLargeException("Request Entity Too Large: The request body has exceeded the maximum size." . $response->getStatusCode());
             case 422:
@@ -65,6 +67,8 @@ class StatusCodeSender implements Sender
                 throw $tooManyRequests;
             case 500:
                 throw new InternalServerErrorException("Internal Server Error." . $response->getStatusCode());
+            case 502:
+                throw new BadGatewayException("Bad Gateway error.");
             case 503:
                 throw new ServiceUnavailableException("Service Unavailable. Try again later." . $response->getStatusCode());
             case 504:

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -43,40 +43,40 @@ class StatusCodeSender implements Sender
             case 200:
                 return $response;
             case 400:
-                throw new BadRequestException("Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON." . $response->getStatusCode());
+                throw new BadRequestException("Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.", $response->getStatusCode());
             case 401:
-                throw new BadCredentialsException("Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials." . $response->getStatusCode());
+                throw new BadCredentialsException("Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.", $response->getStatusCode());
             case 402:
-                throw new PaymentRequiredException("Payment Required: There is no active subscription for the account associated with the credentials submitted with the request." . $response->getStatusCode());
+                throw new PaymentRequiredException("Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.", $response->getStatusCode());
             case 408:
                 throw new RequestTimeoutException("Request timeout error.");
             case 413:
-                throw new RequestEntityTooLargeException("Request Entity Too Large: The request body has exceeded the maximum size." . $response->getStatusCode());
+                throw new RequestEntityTooLargeException("Request Entity Too Large: The request body has exceeded the maximum size.", $response->getStatusCode());
             case 422:
-                throw new UnprocessableEntityException("GET request lacked required fields." . $response->getStatusCode());
+                throw new UnprocessableEntityException("GET request lacked required fields.", $response->getStatusCode());
             case 429:
                 $responseJSON = json_decode($response->getPayload(), true, 10);
 
                 if (! isset($responseJSON['errors'])) {
-                    throw new TooManyRequestsException("The rate limit for the plan associated with this subscription has been exceeded. To see plans with higher rate limits, visit our pricing page." . $response->getStatusCode());
+                    throw new TooManyRequestsException("The rate limit for the plan associated with this subscription has been exceeded. To see plans with higher rate limits, visit our pricing page.", $response->getStatusCode());
                 }
                 $errorMessage = '';
                 foreach($responseJSON['errors'] as $error){
                     $errorMessage .= isset($error['message']) ? $error['message'].' ': '';
                 }
-                $tooManyRequests = new TooManyRequestsException($errorMessage . $response->getStatusCode());
+                $tooManyRequests = new TooManyRequestsException($errorMessage, $response->getStatusCode());
                 $tooManyRequests->setHeader($response->getHeaders());
                 throw $tooManyRequests;
             case 500:
-                throw new InternalServerErrorException("Internal Server Error." . $response->getStatusCode());
+                throw new InternalServerErrorException("Internal Server Error.", $response->getStatusCode());
             case 502:
                 throw new BadGatewayException("Bad Gateway error.");
             case 503:
-                throw new ServiceUnavailableException("Service Unavailable. Try again later." . $response->getStatusCode());
+                throw new ServiceUnavailableException("Service Unavailable. Try again later.", $response->getStatusCode());
             case 504:
-                throw new GatewayTimeoutException("The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed." . $response->getStatusCode());
+                throw new GatewayTimeoutException("The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.", $response->getStatusCode());
             default:
-                throw new SmartyException("Error sending request. Status code is: " . $response->getStatusCode());
+                throw new SmartyException("Error sending request. Status code is: ", $response->getStatusCode());
         }
     }
 }

--- a/tests/International_Autocomplete/ClientTest.php
+++ b/tests/International_Autocomplete/ClientTest.php
@@ -13,6 +13,7 @@ require_once(dirname(dirname(dirname(__FILE__))) . '/src/International_Autocompl
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/International_Autocomplete/Candidate.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/Batch.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/Response.php');
+require_once(dirname(dirname(dirname(__FILE__))) . '/src/Exceptions/SmartyException.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/URLPrefixSender.php');
 use SmartyStreets\PhpSdk\Tests\Mocks\MockSerializer;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockDeserializer;

--- a/tests/Mocks/MockCrashingSender.php
+++ b/tests/Mocks/MockCrashingSender.php
@@ -5,6 +5,7 @@ namespace SmartyStreets\PhpSdk\Tests\Mocks;
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/Sender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/Response.php');
 
+use SmartyStreets\PhpSdk\Exceptions\MustRetryException;
 use SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException;
 use SmartyStreets\PhpSdk\Response;
 use SmartyStreets\PhpSdk\Request;
@@ -21,7 +22,7 @@ class MockCrashingSender implements Sender {
 
         if (strpos($request->getUrl(), "RetryThreeTimes") !== false) {
             if ($this->sendCount <= 3) {
-                throw new \Exception("You need to retry");
+                throw new MustRetryException("You need to retry");
             }
         }
 
@@ -30,7 +31,7 @@ class MockCrashingSender implements Sender {
 
         if (strpos($request->getUrl(), "RetryFifteenTimes") !== false)
             if ($this->sendCount <= 14)
-                throw new \Exception("You need to retry");
+                throw new MustRetryException("You need to retry");
 
         if (strpos($request->getUrl(), "HitRateLimit") !== false)
             if ($this->sendCount <= 1)

--- a/tests/RetrySenderTest.php
+++ b/tests/RetrySenderTest.php
@@ -8,7 +8,6 @@ require_once('Mocks/MockSleeper.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Exceptions/MustRetryException.php');
 require_once(dirname(dirname(__FILE__)) . '/src/RetrySender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
-
 use SmartyStreets\PhpSdk\Tests\Mocks\MockCrashingSender;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockLogger;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockSleeper;

--- a/tests/RetrySenderTest.php
+++ b/tests/RetrySenderTest.php
@@ -5,8 +5,10 @@ namespace SmartyStreets\PhpSdk\Tests;
 require_once('Mocks/MockCrashingSender.php');
 require_once('Mocks/MockLogger.php');
 require_once('Mocks/MockSleeper.php');
+require_once(dirname(dirname(__FILE__)) . '/src/Exceptions/MustRetryException.php');
 require_once(dirname(dirname(__FILE__)) . '/src/RetrySender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
+
 use SmartyStreets\PhpSdk\Tests\Mocks\MockCrashingSender;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockLogger;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockSleeper;

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -5,6 +5,16 @@ namespace SmartyStreets\PhpSdk\Tests;
 require_once('Mocks/MockStatusCodeSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/StatusCodeSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
+
+use SmartyStreets\PhpSdk\Exceptions\BadCredentialsException;
+use SmartyStreets\PhpSdk\Exceptions\BadRequestException;
+use SmartyStreets\PhpSdk\Exceptions\GatewayTimeoutException;
+use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
+use SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException;
+use SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException;
+use SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException;
+use SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException;
+use SmartyStreets\PhpSdk\Exceptions\UnprocessableEntityException;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockStatusCodeSender;
 use SmartyStreets\PhpSdk\StatusCodeSender;
 use SmartyStreets\PhpSdk\Request;
@@ -21,55 +31,55 @@ class StatusCodeSenderTest extends TestCase {
     }
 
     public function test400ResponseThrowsBadRequestException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\BadRequestException::class;
+        $classType = BadRequestException::class;
 
         $this->assertSend(400, $classType);
     }
 
     public function test401ResponseThrowsBadCredentialsException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\BadCredentialsException::class;
+        $classType = BadCredentialsException::class;
 
         $this->assertSend(401, $classType);
     }
 
     public function test402ResponseThrowsPaymentRequiredException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException::class;
+        $classType = PaymentRequiredException::class;
 
         $this->assertSend(402, $classType);
     }
 
     public function test413ResponseThrowsRequestEntityTooLargeException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException::class;
+        $classType = RequestEntityTooLargeException::class;
 
         $this->assertSend(413, $classType);
     }
 
     public function test422ResponseThrowsUnprocessableEntityException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\UnprocessableEntityException::class;
+        $classType = UnprocessableEntityException::class;
 
         $this->assertSend(422, $classType);
     }
 
     public function test429ResponseThrowsTooManyRequestsException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException::class;
+        $classType = TooManyRequestsException::class;
 
         $this->assertSend(429, $classType);
     }
 
     public function test500ResponseThrowsInternalServerErrorException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException::class;
+        $classType = InternalServerErrorException::class;
 
         $this->assertSend(500, $classType);
     }
 
     public function test503ResponseThrowsServiceUnavailableException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException::class;
+        $classType = ServiceUnavailableException::class;
 
         $this->assertSend(503, $classType);
     }
 
     public function test504ResponseThrowsGatewayTimeoutException() {
-        $classType = \SmartyStreets\PhpSdk\Exceptions\GatewayTimeoutException::class;
+        $classType = GatewayTimeoutException::class;
 
         $this->assertSend(504, $classType);
     }

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -32,7 +32,7 @@ class StatusCodeSenderTest extends TestCase {
         $this->assertSend(401, $classType);
     }
 
-    public function test402ResponsePThrowsPaymentRequiredException() {
+    public function test402ResponseThrowsPaymentRequiredException() {
         $classType = \SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException::class;
 
         $this->assertSend(402, $classType);


### PR DESCRIPTION
EXAMPLES: Mostly cosmetic changes so the examples match each other better
- InternationalAutocompleteExample: Added try/catch block
- InternationalExample: Added try/catch block, separated printing of results into separate function (public, maybe should be made private)
- USAutocompleteProExample: Added try/catch block, separated printing of results into separate functions (these ones are private)
- USExtractExample: Added try/catch block, separated printing of results into separate function (public, maybe should be made private)
- USReverseGeoExample: Added try/catch block, separated printing of results into separate function (public, maybe should be made private)
- USStreetLookupsWithMatchStrategyExamples: Removed unnecessary try/catch block

NOTE: These have a different naming convention (Us vs the above US, which ones should it be?)
- UsStreetMultipleAddressesExample: Removed unnecessary try/catch block
- UsStreetSingleAddressExample: Removed unnecessary try/catch block
- UsZIPCodeMultipleLookupsExample: Removed unnecessary try/catch block
- UsZIPCodeSingleLookupExample: Removed unnecessary try/catch block

EXCEPTIONS: Added three new exceptions.
- Added RequestTimeoutException (408)
- Added BadGatewayException (502)
- Added MustRetryException: Specifically for testing, we may be able to get rid of this with some additional work
- Added a parent constructor to SmartyException so users can use getCode on the SmartyExceptions (GitHub issue #20 https://github.com/smartystreets/smartystreets-php-sdk/issues/20)

SRC: Updated RetrySender to only retry specific status codes. Added status codes to exceptions thrown in StatusCodeSender.
- RetrySender: Only retries specific status codes (specified by the Ruby SDK: 408, 429, 500, 502, 503, 504)
- StatusCodeSender: Added status codes to exceptions thrown, added new exceptions (RequestTimeoutException and BadGatewayException). Declared $errorMessage variable outside the foreach loop to remove the variable undefined variable error (GitHub issue #40 https://github.com/smartystreets/smartystreets-php-sdk/issues/40)

TESTS: Mostly cosmetic changes
- International Autocomplete ClientTest: Added require SmartyException
- Mocks: Changed exceptions thrown when a retry is needed to MustRetryException to ensure that the request is retried. We can also change this to be another exception class that is retried (408, 429, 500, 502, 503, 504) but I decided to just make a new exception class for now. We can change that
- RetrySenderTest: Added require MustRetryException
- StatusCodeSenderTest: Added use statements for exceptions and removed \SmartyStreets\PhpSdk\Exceptions\ from the beginning of each exception class type. I can also revert this. Changed test402ResponsePThrowsPaymentRequiredException test name to remove the extra P in the name