### PR TITLE
X_FORWARDED_FOR header added

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -60,7 +60,8 @@ class ClientBuilder {
             $proxy,
             $logger,
             $debugMode,
-            $licenses;
+            $licenses,
+            $ip;
 
     public function __construct(Credentials $signer = null) {
         $this->serializer = new NativeSerializer();
@@ -70,6 +71,7 @@ class ClientBuilder {
         $this->logger = new MyLogger();
         $this->debugMode = false;
         $this->licenses = [];
+        $this->ip = null;
     }
 
     /**
@@ -165,6 +167,16 @@ class ClientBuilder {
         return $this;
     }
 
+    /**
+     * Allows the caller to include an X-Forwarded-For header in their request, passing on the end user's IP address
+     * @param string $ip The IP of the end user
+     * @return $this Returns <b>this</b> to accommodate method chaining.
+     */
+    public function withXForwardedFor($ip) {
+        $this->ip = $ip;
+        return $this;
+    }
+
     public function buildUSAutocompleteApiClient() {
         $this->ensureURLPrefixNotNull(self::US_AUTOCOMPLETE_API_URL);
         return new USAutoCompleteApiClient($this->buildSender(), $this->serializer);
@@ -214,7 +226,7 @@ class ClientBuilder {
         if ($this->httpSender != null)
             return $this->httpSender;
 
-        $sender = new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode);
+        $sender = new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode, $this->ip);
 
         $sender = new StatusCodeSender($sender);
 

--- a/src/NativeSender.php
+++ b/src/NativeSender.php
@@ -18,13 +18,15 @@ class NativeSender implements Sender
 
     private $maxTimeOut,
         $proxy,
-        $debugMode;
+        $debugMode,
+        $ip;
 
-    public function __construct($maxTimeOut = 10000, Proxy $proxy = null, $debugMode = false)
+    public function __construct($maxTimeOut = 10000, Proxy $proxy = null, $debugMode = false, $ip = null)
     {
         $this->maxTimeOut = $maxTimeOut;
         $this->proxy = $proxy;
         $this->debugMode = $debugMode;
+        $this->ip = $ip;
     }
 
     function send(Request $smartyRequest)
@@ -80,6 +82,10 @@ class NativeSender implements Sender
 
         if ($smartyRequest->getReferer() != null)
             curl_setopt($ch, CURLOPT_REFERER, $smartyRequest->getReferer());
+        if ($this->ip != null) {
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array("X_FORWARDED_FOR: $this->ip"));
+            $smartyRequest->setHeader('X_FORWARDED_FOR', $this->ip);
+        }
 
         return $ch;
     }

--- a/tests/XForwardedForTest.php
+++ b/tests/XForwardedForTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Tests;
+
+require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
+require_once(dirname(dirname(__FILE__)) . '/src/Response.php');
+require_once(dirname(dirname(__FILE__)) . '/src/NativeSender.php');
+require_once(dirname(dirname(__FILE__)) . '/src/Proxy.php');
+require_once('Mocks/MockSender.php');
+use SmartyStreets\PhpSdk\Proxy;
+use SmartyStreets\PhpSdk\Request;
+use SmartyStreets\PhpSdk\Response;
+use SmartyStreets\PhpSdk\NativeSender;
+use SmartyStreets\PhpSdk\Tests\Mocks\MockSender;
+use PHPUnit\Framework\TestCase;
+
+class XForwardedForTest extends TestCase {
+    public function testNativeSetOnQuery() {
+        $request = new Request();
+        //$licenses = ["one","two","three"];
+        //$inner = new MockSender(new Response(123, null, ""));
+        $sender = new NativeSender(10000, null, false, "0.0.0.0");
+
+        $sender->send($request);
+
+        $this->assertEquals("0.0.0.0", $request->getHeaders()["X_FORWARDED_FOR"]);
+    }
+
+    public function testNativeNotSet() {
+        $request = new Request();
+        //$inner = new MockSender(new Response(123, null, ""));
+        $sender = new NativeSender();
+
+        $sender->send($request);
+
+        $this->assertEquals(null, $request->getHeaders()["X_FORWARDED_FOR"]);
+    }
+}


### PR DESCRIPTION
Added option to send the X_FORWARDED_FOR header with requests, mainly to facilitate usage of the ip geolocation feature of the US Autocomplete Pro API. The IP is passed as a string parameter of the ClientBuilder method withXForwardedFor.