### PR TITLE
make max candidates default for us-street-api be 1 - the same as the api itself.

### DIFF
--- a/src/US_Street/Lookup.php
+++ b/src/US_Street/Lookup.php
@@ -211,8 +211,6 @@ class Lookup implements \JsonSerializable {
      * @param $matchStrategy string The match output strategy
      */
     public function setMatchStrategy($matchStrategy) {
-        if ($matchStrategy == self::ENHANCED && $this->maxCandidates == 1)
-            $this->maxCandidates = 5;
         $this->matchStrategy = $matchStrategy;
     }
 

--- a/tests/US_Street/ClientTest.php
+++ b/tests/US_Street/ClientTest.php
@@ -47,7 +47,7 @@ class ClientTest extends TestCase {
         $serializer = new NativeSerializer();
         $expectedURL = ("http://localhost/street-address?input_id=1&street=2&street2=3&secondary=4&city=5&" .
             "state=6&zipcode=7&lastline=8&addressee=9&" .
-            "urbanization=10&match=enhanced&candidates=5");
+            "urbanization=10&match=enhanced&candidates=1");
 
         $client = new Client($sender, $serializer);
         $lookup = new Lookup();
@@ -75,7 +75,7 @@ class ClientTest extends TestCase {
         $serializer = new NativeSerializer();
         $expectedURL = ("http://localhost/street-address?input_id=1&street=2&street2=3&secondary=4&city=5&" .
             "state=6&zipcode=7&lastline=8&addressee=9&" .
-            "urbanization=10&match=enhanced&candidates=5&parameter=custom&second=parameter");
+            "urbanization=10&match=enhanced&candidates=1&parameter=custom&second=parameter");
 
         $client = new Client($sender, $serializer);
         $lookup = new Lookup();
@@ -105,7 +105,7 @@ class ClientTest extends TestCase {
         $serializer = new NativeSerializer();
         $expectedURL = ("http://localhost/street-address?input_id=1&street=2&street2=3&secondary=4&city=5&" .
             "state=6&zipcode=7&lastline=8&addressee=9&" .
-            "urbanization=10&match=enhanced&format=project-usa&candidates=5");
+            "urbanization=10&match=enhanced&format=project-usa&candidates=1");
 
         $client = new Client($sender, $serializer);
         $lookup = new Lookup();


### PR DESCRIPTION
make max candidates default for us-street-api be 1 - the same as the api itself.