### PR TITLE
Add withSender() option with middleware 
  chain and conflict validation

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -36,6 +36,7 @@ require_once(__DIR__ . '/International_Postal_Code/Client.php');
 require_once(__DIR__ . '/US_Reverse_Geo/Client.php');
 require_once(__DIR__ . '/US_Enrichment/Client.php');
 require_once(__DIR__ . '/CustomQuerySender.php');
+require_once(__DIR__ . '/CustomHeaderSender.php');
 
 
 /**
@@ -57,7 +58,6 @@ class ClientBuilder {
     private $signer,
             $serializer,
             $httpSender,
-            $wrappedHttpSender,
             $maxRetries,
             $maxTimeout,
             $urlPrefix,
@@ -82,7 +82,6 @@ class ClientBuilder {
         $this->appendHeaders = [];
         $this->ip = null;
         $this->customQuery = [];
-        $this->wrappedHttpSender = null;
     }
 
     /**
@@ -126,16 +125,6 @@ class ClientBuilder {
      */
     public function withSender(Sender $sender) {
         $this->httpSender = $sender;
-        return $this;
-    }
-
-    /**
-     * Replaces the innermost NativeSender while keeping the rest of the sender chain intact.
-     * @param Sender $sender The sender to use as the HTTP transport layer.
-     * @return $this Returns <b>this</b> to accommodate method chaining.
-     */
-    public function withWrappedSender(Sender $sender) {
-        $this->wrappedHttpSender = $sender;
         return $this;
     }
 
@@ -300,12 +289,17 @@ class ClientBuilder {
     }
 
     private function buildSender() {
-        if ($this->httpSender != null)
-            return $this->httpSender;
-
-        $sender = $this->wrappedHttpSender ?? new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode, $this->ip, $this->customHeaders, $this->appendHeaders);
+        $sender = $this->httpSender ?? new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode);
 
         $sender = new StatusCodeSender($sender);
+
+        $effectiveHeaders = $this->customHeaders;
+        if ($this->ip !== null) {
+            $effectiveHeaders['X-Forwarded-For'] = $this->ip;
+        }
+        if (!empty($effectiveHeaders)) {
+            $sender = new CustomHeaderSender($effectiveHeaders, $sender, $this->appendHeaders);
+        }
 
         if ($this->maxRetries > 0)
             $sender = new RetrySender($this->maxRetries, new MySleeper(), $this->logger, $sender);

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -57,6 +57,7 @@ class ClientBuilder {
     private $signer,
             $serializer,
             $httpSender,
+            $wrappedHttpSender,
             $maxRetries,
             $maxTimeout,
             $urlPrefix,
@@ -81,6 +82,7 @@ class ClientBuilder {
         $this->appendHeaders = [];
         $this->ip = null;
         $this->customQuery = [];
+        $this->wrappedHttpSender = null;
     }
 
     /**
@@ -124,6 +126,16 @@ class ClientBuilder {
      */
     public function withSender(Sender $sender) {
         $this->httpSender = $sender;
+        return $this;
+    }
+
+    /**
+     * Replaces the innermost NativeSender while keeping the rest of the sender chain intact.
+     * @param Sender $sender The sender to use as the HTTP transport layer.
+     * @return $this Returns <b>this</b> to accommodate method chaining.
+     */
+    public function withWrappedSender(Sender $sender) {
+        $this->wrappedHttpSender = $sender;
         return $this;
     }
 
@@ -291,7 +303,7 @@ class ClientBuilder {
         if ($this->httpSender != null)
             return $this->httpSender;
 
-        $sender = new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode, $this->ip, $this->customHeaders, $this->appendHeaders);
+        $sender = $this->wrappedHttpSender ?? new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode, $this->ip, $this->customHeaders, $this->appendHeaders);
 
         $sender = new StatusCodeSender($sender);
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -289,6 +289,14 @@ class ClientBuilder {
     }
 
     private function buildSender() {
+        if ($this->httpSender !== null) {
+            $conflicts = [];
+            if ($this->maxTimeout !== 10000) $conflicts[] = 'withMaxTimeout()';
+            if ($this->proxy !== null) $conflicts[] = 'viaProxy()';
+            if ($this->debugMode !== false) $conflicts[] = 'withDebug()';
+            if (!empty($conflicts))
+                throw new \InvalidArgumentException('withSender() cannot be combined with: ' . implode(', ', $conflicts) . '. These options only apply to the built-in HTTP transport.');
+        }
         $sender = $this->httpSender ?? new NativeSender($this->maxTimeout, $this->proxy, $this->debugMode);
 
         $sender = new StatusCodeSender($sender);

--- a/src/CustomHeaderSender.php
+++ b/src/CustomHeaderSender.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SmartyStreets\PhpSdk;
+
+require_once(__DIR__ . '/Sender.php');
+
+class CustomHeaderSender implements Sender
+{
+    private $customHeaders;
+    private $appendHeaders;
+    private $inner;
+
+    public function __construct(array $customHeaders, Sender $inner, array $appendHeaders = []) {
+        $this->customHeaders = $customHeaders;
+        $this->inner = $inner;
+        $this->appendHeaders = $appendHeaders;
+    }
+
+    public function send(Request $request) {
+        foreach ($this->customHeaders as $key => $value) {
+            $appendKey = $this->findAppendHeaderKey($key);
+            if ($appendKey !== null) {
+                $separator = $this->appendHeaders[$appendKey];
+                $headers = $request->getHeaders();
+                $existingKey = null;
+                foreach ($headers as $hk => $hv) {
+                    if (strcasecmp($hk, $key) === 0) {
+                        $existingKey = $hk;
+                        break;
+                    }
+                }
+                $existing = $existingKey !== null ? $headers[$existingKey] : '';
+                $headerKey = $existingKey !== null ? $existingKey : $key;
+                $request->setHeader($headerKey, $existing !== '' ? $existing . $separator . $value : $value);
+            } else {
+                $request->setHeader($key, $value);
+            }
+        }
+        return $this->inner->send($request);
+    }
+
+    private function findAppendHeaderKey($header) {
+        foreach ($this->appendHeaders as $key => $separator) {
+            if (strcasecmp($key, $header) === 0) {
+                return $key;
+            }
+        }
+        return null;
+    }
+}

--- a/src/NativeSender.php
+++ b/src/NativeSender.php
@@ -14,18 +14,12 @@ class NativeSender implements Sender
 {
     private $maxTimeOut,
         $proxy,
-        $debugMode,
-        $ip,
-        $customHeaders,
-        $appendHeaders;
+        $debugMode;
 
-    public function __construct($maxTimeOut = 10000, ?Proxy $proxy = null, $debugMode = false, $ip = null, $customHeaders = [], $appendHeaders = []) {
+    public function __construct($maxTimeOut = 10000, ?Proxy $proxy = null, $debugMode = false) {
         $this->maxTimeOut = $maxTimeOut;
         $this->proxy = $proxy;
         $this->debugMode = $debugMode;
-        $this->ip = $ip;
-        $this->customHeaders = $customHeaders;
-        $this->appendHeaders = $appendHeaders;
     }
 
     function send(Request $smartyRequest) {
@@ -68,7 +62,6 @@ class NativeSender implements Sender
         curl_setopt($ch, CURLOPT_POSTFIELDS, ($smartyRequest->getPayload()));
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $this->maxTimeOut);
-        curl_setopt($ch, CURLOPT_USERAGENT, $this->buildUserAgent());
         if ($this->debugMode && defined("STDERR"))
             curl_setopt($ch, CURLINFO_HEADER_OUT, true);
         if ($this->proxy != null)
@@ -77,74 +70,22 @@ class NativeSender implements Sender
         if ($smartyRequest->getReferer() != null)
             curl_setopt($ch, CURLOPT_REFERER, $smartyRequest->getReferer());
 
-        // Headers
         $smartyRequest->setHeader('Content-Type', $smartyRequest->getContentType());
-        if ($this->ip != null) {
-            $smartyRequest->setHeader('X-Forwarded-For', $this->ip);
-        }
-        if (count($this->customHeaders) != 0) {
-            foreach ($this->customHeaders as $key => $value) {
-                // User-Agent is handled via CURLOPT_USERAGENT in buildUserAgent()
-                if (strcasecmp($key, 'User-Agent') === 0) {
-                    continue;
-                }
-                $appendKey = $this->findAppendHeaderKey($key);
-                if ($appendKey !== null) {
-                    $separator = $this->appendHeaders[$appendKey];
-                    $headers = $smartyRequest->getHeaders();
-                    $existingKey = null;
-                    foreach ($headers as $hk => $hv) {
-                        if (strcasecmp($hk, $key) === 0) {
-                            $existingKey = $hk;
-                            break;
-                        }
-                    }
-                    $existing = $existingKey !== null ? $headers[$existingKey] : '';
-                    $headerKey = $existingKey !== null ? $existingKey : $key;
-                    $smartyRequest->setHeader($headerKey, $existing !== '' ? $existing . $separator . $value : $value);
-                } else {
-                    $smartyRequest->setHeader($key, $value);
-                }
-            }
-        }
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getCURLOPTHeaders($smartyRequest));
 
-        return $ch;
-    }
-
-    protected function buildUserAgent() {
-        $userAgent = 'smartystreets (sdk:php@' . VERSION . ')';
-
-        $customUAKey = null;
-        foreach ($this->customHeaders as $key => $value) {
+        $hasUserAgent = false;
+        foreach ($smartyRequest->getHeaders() as $key => $value) {
             if (strcasecmp($key, 'User-Agent') === 0) {
-                $customUAKey = $key;
+                $hasUserAgent = true;
                 break;
             }
         }
-
-        if ($customUAKey === null) {
-            return $userAgent;
+        if (!$hasUserAgent) {
+            $smartyRequest->setHeader('User-Agent', 'smartystreets (sdk:php@' . VERSION . ')');
         }
 
-        $appendKey = $this->findAppendHeaderKey('User-Agent');
-        if ($appendKey !== null) {
-            $separator = $this->appendHeaders[$appendKey];
-            $userAgent = $userAgent . $separator . $this->customHeaders[$customUAKey];
-        } else {
-            $userAgent = $this->customHeaders[$customUAKey];
-        }
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $this->getCURLOPTHeaders($smartyRequest));
 
-        return $userAgent;
-    }
-
-    private function findAppendHeaderKey($header) {
-        foreach ($this->appendHeaders as $key => $separator) {
-            if (strcasecmp($key, $header) === 0) {
-                return $key;
-            }
-        }
-        return null;
+        return $ch;
     }
 
     private function setProxy(&$ch) {

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -29,11 +29,11 @@ class ClientBuilderTest extends TestCase {
         $this->assertEquals('component-analysis,iana-timezone', $this->getCustomQuery($builder)['features']);
     }
 
-    public function testWithWrappedSender_WrapsWithMiddlewareChain() {
+    public function testWithSender_WrapsWithMiddlewareChain() {
         $capturingSender = new RequestCapturingSender();
         $credentials = new StaticCredentials('test-id', 'test-token');
         $client = (new ClientBuilder($credentials))
-            ->withWrappedSender($capturingSender)
+            ->withSender($capturingSender)
             ->buildUsStreetApiClient();
 
         $lookup = new \SmartyStreets\PhpSdk\US_Street\Lookup('1 Rosedale');

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -29,6 +29,26 @@ class ClientBuilderTest extends TestCase {
         $this->assertEquals('component-analysis,iana-timezone', $this->getCustomQuery($builder)['features']);
     }
 
+    public function testWithSender_ThrowsWhenCombinedWithMaxTimeout() {
+        $this->expectException(\InvalidArgumentException::class);
+        $capturingSender = new RequestCapturingSender();
+        $credentials = new StaticCredentials('test-id', 'test-token');
+        (new ClientBuilder($credentials))
+            ->withSender($capturingSender)
+            ->withMaxTimeout(5000)
+            ->buildUsStreetApiClient();
+    }
+
+    public function testWithSender_ThrowsWhenCombinedWithProxy() {
+        $this->expectException(\InvalidArgumentException::class);
+        $capturingSender = new RequestCapturingSender();
+        $credentials = new StaticCredentials('test-id', 'test-token');
+        (new ClientBuilder($credentials))
+            ->withSender($capturingSender)
+            ->viaProxy('http://localhost:8080')
+            ->buildUsStreetApiClient();
+    }
+
     public function testWithSender_WrapsWithMiddlewareChain() {
         $capturingSender = new RequestCapturingSender();
         $credentials = new StaticCredentials('test-id', 'test-token');

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -3,8 +3,13 @@
 namespace SmartyStreets\PhpSdk\Tests;
 
 require_once(dirname(dirname(__FILE__)) . '/src/ClientBuilder.php');
+require_once(dirname(dirname(__FILE__)) . '/src/StaticCredentials.php');
+require_once(dirname(dirname(__FILE__)) . '/src/US_Street/Lookup.php');
+require_once(dirname(__FILE__) . '/Mocks/RequestCapturingSender.php');
 
 use SmartyStreets\PhpSdk\ClientBuilder;
+use SmartyStreets\PhpSdk\StaticCredentials;
+use SmartyStreets\PhpSdk\Tests\Mocks\RequestCapturingSender;
 use PHPUnit\Framework\TestCase;
 
 class ClientBuilderTest extends TestCase {
@@ -22,6 +27,22 @@ class ClientBuilderTest extends TestCase {
         $builder->withFeatureIanaTimeZone();
 
         $this->assertEquals('component-analysis,iana-timezone', $this->getCustomQuery($builder)['features']);
+    }
+
+    public function testWithWrappedSender_WrapsWithMiddlewareChain() {
+        $capturingSender = new RequestCapturingSender();
+        $credentials = new StaticCredentials('test-id', 'test-token');
+        $client = (new ClientBuilder($credentials))
+            ->withWrappedSender($capturingSender)
+            ->buildUsStreetApiClient();
+
+        $lookup = new \SmartyStreets\PhpSdk\US_Street\Lookup('1 Rosedale');
+        $client->sendLookup($lookup);
+
+        $url = $capturingSender->getRequest()->getUrl();
+        $this->assertStringContainsString('us-street.api.smarty.com', $url);
+        $this->assertStringContainsString('auth-id=test-id', $url);
+        $this->assertStringContainsString('auth-token=test-token', $url);
     }
 
     private function getCustomQuery(ClientBuilder $builder) {

--- a/tests/CustomHeaderTest.php
+++ b/tests/CustomHeaderTest.php
@@ -3,156 +3,121 @@
 namespace SmartyStreets\PhpSdk\Tests;
 
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
-require_once(dirname(dirname(__FILE__)) . '/src/NativeSender.php');
-require_once(dirname(dirname(__FILE__)) . '/src/Exceptions/SmartyException.php');
+require_once(dirname(dirname(__FILE__)) . '/src/CustomHeaderSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/ClientBuilder.php');
+require_once('Mocks/RequestCapturingSender.php');
 use SmartyStreets\PhpSdk\Request;
-use SmartyStreets\PhpSdk\NativeSender;
+use SmartyStreets\PhpSdk\CustomHeaderSender;
 use SmartyStreets\PhpSdk\ClientBuilder;
-use SmartyStreets\PhpSdk\Exceptions\SmartyException;
+use SmartyStreets\PhpSdk\Tests\Mocks\RequestCapturingSender;
 use PHPUnit\Framework\TestCase;
 
-class TestableSender extends NativeSender {
-    public function exposeBuildUserAgent() {
-        return $this->buildUserAgent();
-    }
-}
-
 class CustomHeaderTest extends TestCase {
-    public function testNativeSetOnQuery() {
+    public function testCustomHeaderSenderSetsHeader() {
         $request = new Request();
-        $sender = new NativeSender(10000, null, false, null, ["Header" => "Custom"]);
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['Header' => 'Custom'], $inner);
 
-        try {
         $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
 
-        $this->assertEquals("Custom", $request->getHeaders()["Header"]);
-    }
-
-    public function testAppendedHeadersAreNotSetAsRegularHeaders() {
-        $request = new Request();
-        $sender = new NativeSender(10000, null, false, null, ["User-Agent" => "custom-value"], ["User-Agent" => " "]);
-
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
-
-        $this->assertArrayNotHasKey("User-Agent", $request->getHeaders());
-    }
-
-    public function testRegularCustomHeadersStillSetWhenAppendedHeadersPresent() {
-        $request = new Request();
-        $sender = new NativeSender(10000, null, false, null, ["Header" => "Custom", "User-Agent" => "custom-value"], ["User-Agent" => " "]);
-
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
-
-        $this->assertEquals("Custom", $request->getHeaders()["Header"]);
-        $this->assertArrayNotHasKey("User-Agent", $request->getHeaders());
+        $this->assertEquals('Custom', $inner->getRequest()->getHeaders()['Header']);
     }
 
     public function testAppendedNonUserAgentHeaderAppendsToExistingValue() {
         $request = new Request();
         $request->setHeader('Accept', 'application/json');
-        $sender = new NativeSender(10000, null, false, null, ["Accept" => "text/html"], ["Accept" => ", "]);
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['Accept' => 'text/html'], $inner, ['Accept' => ', ']);
 
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
+        $sender->send($request);
 
-        $this->assertEquals("application/json, text/html", $request->getHeaders()["Accept"]);
+        $this->assertEquals('application/json, text/html', $inner->getRequest()->getHeaders()['Accept']);
     }
 
     public function testAppendedHeaderIsCaseInsensitiveWithExistingHeader() {
         $request = new Request();
         $request->setHeader('Content-Type', 'application/json');
-        $sender = new NativeSender(10000, null, false, null, ["content-type" => "text/html"], ["content-type" => ", "]);
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['content-type' => 'text/html'], $inner, ['content-type' => ', ']);
 
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
+        $sender->send($request);
 
-        $this->assertEquals("application/json, text/html", $request->getHeaders()["Content-Type"]);
-        $this->assertArrayNotHasKey("content-type", $request->getHeaders());
+        $this->assertEquals('application/json, text/html', $inner->getRequest()->getHeaders()['Content-Type']);
+        $this->assertArrayNotHasKey('content-type', $inner->getRequest()->getHeaders());
     }
 
     public function testAppendedNonUserAgentHeaderSetsValueWhenNoExisting() {
         $request = new Request();
-        $sender = new NativeSender(10000, null, false, null, ["X-Custom" => "value"], ["X-Custom" => "; "]);
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['X-Custom' => 'value'], $inner, ['X-Custom' => '; ']);
 
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
+        $sender->send($request);
 
-        $this->assertEquals("value", $request->getHeaders()["X-Custom"]);
+        $this->assertEquals('value', $inner->getRequest()->getHeaders()['X-Custom']);
     }
 
-    public function testUserAgentContainsSDKVersionByDefault() {
-        $sender = new TestableSender();
-        $userAgent = $sender->exposeBuildUserAgent();
+    public function testUserAgentSetWhenSpecifiedAsCustomHeader() {
+        $request = new Request();
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['User-Agent' => 'custom-app'], $inner);
 
-        $this->assertStringContainsString('smartystreets (sdk:php@', $userAgent);
+        $sender->send($request);
+
+        $this->assertEquals('custom-app', $inner->getRequest()->getHeaders()['User-Agent']);
     }
 
-    public function testUserAgentAppendsCustomValueWithSeparator() {
-        $sender = new TestableSender(10000, null, false, null, ["User-Agent" => "custom-app"], ["User-Agent" => " "]);
-        $userAgent = $sender->exposeBuildUserAgent();
+    public function testUserAgentCaseInsensitiveReplacement() {
+        $request = new Request();
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['user-agent' => 'custom-app'], $inner);
 
-        $this->assertStringStartsWith('smartystreets (sdk:php@', $userAgent);
-        $this->assertStringEndsWith(' custom-app', $userAgent);
+        $sender->send($request);
+
+        $this->assertEquals('custom-app', $inner->getRequest()->getHeaders()['user-agent']);
     }
 
-    public function testUserAgentUsesProvidedSeparator() {
-        $sender = new TestableSender(10000, null, false, null, ["User-Agent" => "custom-app"], ["User-Agent" => " - "]);
-        $userAgent = $sender->exposeBuildUserAgent();
+    public function testAppendedUserAgentAppendsToExistingRequestUserAgent() {
+        $request = new Request();
+        $request->setHeader('User-Agent', 'existing-agent');
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['User-Agent' => 'custom-app'], $inner, ['User-Agent' => ' ']);
 
-        $this->assertStringContainsString(') - custom-app', $userAgent);
+        $sender->send($request);
+
+        $this->assertEquals('existing-agent custom-app', $inner->getRequest()->getHeaders()['User-Agent']);
     }
 
-    public function testUserAgentReplacedWhenNoAppendHeader() {
-        $sender = new TestableSender(10000, null, false, null, ["User-Agent" => "custom-app"], []);
-        $userAgent = $sender->exposeBuildUserAgent();
+    public function testAppendedUserAgentSetsValueWhenNoExistingUserAgent() {
+        $request = new Request();
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['User-Agent' => 'custom-app'], $inner, ['User-Agent' => ' ']);
 
-        $this->assertEquals('custom-app', $userAgent);
+        $sender->send($request);
+
+        $this->assertEquals('custom-app', $inner->getRequest()->getHeaders()['User-Agent']);
     }
 
-    public function testWithCustomHeaderReplacesUserAgent() {
-        $sender = new TestableSender(10000, null, false, null, ["User-Agent" => "my-app"], []);
-        $userAgent = $sender->exposeBuildUserAgent();
+    public function testRegularCustomHeadersSetAlongsideUserAgent() {
+        $request = new Request();
+        $inner = new RequestCapturingSender();
+        $sender = new CustomHeaderSender(['Header' => 'Custom', 'User-Agent' => 'custom-app'], $inner, ['User-Agent' => ' ']);
 
-        $this->assertEquals("my-app", $userAgent);
+        $sender->send($request);
+
+        $this->assertEquals('Custom', $inner->getRequest()->getHeaders()['Header']);
+        $this->assertEquals('custom-app', $inner->getRequest()->getHeaders()['User-Agent']);
     }
 
-    public function testWithCustomHeaderReplacesUserAgentCaseInsensitive() {
-        $sender = new TestableSender(10000, null, false, null, ["user-agent" => "my-app"], []);
-        $userAgent = $sender->exposeBuildUserAgent();
-
-        $this->assertEquals("my-app", $userAgent);
-    }
-
-    public function testWithCustomHeaderAfterWithAppendedHeaderRemovesAppendBehavior() {
+    public function testAppendHeaderAfterCustomHeaderReplacesValue() {
         $request = new Request();
         $request->setHeader('Accept', 'application/json');
-        // Simulate calling withAppendedHeader then withCustomHeader on ClientBuilder:
-        // withAppendedHeader sets both customHeaders and appendHeaders,
-        // withCustomHeader should remove from appendHeaders, making it a replacement.
-        $sender = new NativeSender(10000, null, false, null, ["Accept" => "text/html"], []);
+        $inner = new RequestCapturingSender();
+        // No append entry for Accept — should replace
+        $sender = new CustomHeaderSender(['Accept' => 'text/html'], $inner, []);
 
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
+        $sender->send($request);
 
-        // The header should be replaced, not appended
-        $this->assertEquals("text/html", $request->getHeaders()["Accept"]);
+        $this->assertEquals('text/html', $inner->getRequest()->getHeaders()['Accept']);
     }
 
     public function testBuilderWithCustomHeaderAfterAppendedHeaderRemovesAppendBehavior() {

--- a/tests/XForwardedForTest.php
+++ b/tests/XForwardedForTest.php
@@ -2,45 +2,56 @@
 
 namespace SmartyStreets\PhpSdk\Tests;
 
-require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
-require_once(dirname(dirname(__FILE__)) . '/src/Response.php');
-require_once(dirname(dirname(__FILE__)) . '/src/NativeSender.php');
-require_once(dirname(dirname(__FILE__)) . '/src/Proxy.php');
-require_once(dirname(dirname(__FILE__)) . '/src/Exceptions/SmartyException.php');
-require_once('Mocks/MockSender.php');
-use SmartyStreets\PhpSdk\Proxy;
-use SmartyStreets\PhpSdk\Request;
-use SmartyStreets\PhpSdk\Response;
-use SmartyStreets\PhpSdk\NativeSender;
-use SmartyStreets\PhpSdk\Tests\Mocks\MockSender;
-use SmartyStreets\PhpSdk\Exceptions\SmartyException;
+require_once(dirname(dirname(__FILE__)) . '/src/ClientBuilder.php');
+require_once(dirname(dirname(__FILE__)) . '/src/StaticCredentials.php');
+require_once(dirname(dirname(__FILE__)) . '/src/US_Street/Lookup.php');
+require_once('Mocks/RequestCapturingSender.php');
+use SmartyStreets\PhpSdk\ClientBuilder;
+use SmartyStreets\PhpSdk\StaticCredentials;
+use SmartyStreets\PhpSdk\Tests\Mocks\RequestCapturingSender;
 use PHPUnit\Framework\TestCase;
 
 class XForwardedForTest extends TestCase {
-    public function testNativeSetOnQuery() {
-        $request = new Request();
-        //$licenses = ["one","two","three"];
-        //$inner = new MockSender(new Response(123, null, ""));
-        $sender = new NativeSender(10000, null, false, "0.0.0.0");
+    public function testXForwardedForHeaderSetViaClientBuilder() {
+        $capturingSender = new RequestCapturingSender();
+        $credentials = new StaticCredentials('test-id', 'test-token');
+        $client = (new ClientBuilder($credentials))
+            ->withXForwardedFor('0.0.0.0')
+            ->withSender($capturingSender)
+            ->buildUsStreetApiClient();
 
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
-        $this->assertEquals("0.0.0.0", $request->getHeaders()["X-Forwarded-For"]);
+        $lookup = new \SmartyStreets\PhpSdk\US_Street\Lookup('1 Rosedale');
+        $client->sendLookup($lookup);
+
+        $this->assertEquals('0.0.0.0', $capturingSender->getRequest()->getHeaders()['X-Forwarded-For']);
     }
 
-    public function testNativeNotSet() {
-        $request = new Request();
-        //$inner = new MockSender(new Response(123, null, ""));
-        $sender = new NativeSender();
+    public function testXForwardedForNotSetWhenNotConfigured() {
+        $capturingSender = new RequestCapturingSender();
+        $credentials = new StaticCredentials('test-id', 'test-token');
+        $client = (new ClientBuilder($credentials))
+            ->withSender($capturingSender)
+            ->buildUsStreetApiClient();
 
-        try {
-            $sender->send($request);
-        } catch (SmartyException $ex) {
-        }
-        $headers = $request->getHeaders();
+        $lookup = new \SmartyStreets\PhpSdk\US_Street\Lookup('1 Rosedale');
+        $client->sendLookup($lookup);
 
-        $this->assertEquals(false, array_key_exists("X-Forwarded-For", $headers));
+        $this->assertArrayNotHasKey('X-Forwarded-For', $capturingSender->getRequest()->getHeaders());
+    }
+
+    public function testXForwardedForCombinedWithCustomHeaders() {
+        $capturingSender = new RequestCapturingSender();
+        $credentials = new StaticCredentials('test-id', 'test-token');
+        $client = (new ClientBuilder($credentials))
+            ->withXForwardedFor('0.0.0.0')
+            ->withCustomHeader('X-Custom', 'value')
+            ->withSender($capturingSender)
+            ->buildUsStreetApiClient();
+
+        $lookup = new \SmartyStreets\PhpSdk\US_Street\Lookup('1 Rosedale');
+        $client->sendLookup($lookup);
+
+        $this->assertEquals('0.0.0.0', $capturingSender->getRequest()->getHeaders()['X-Forwarded-For']);
+        $this->assertEquals('value', $capturingSender->getRequest()->getHeaders()['X-Custom']);
     }
 }


### PR DESCRIPTION
## Summary
- Added `withSender()` option to `ClientBuilder`, allowing a custom HTTP sender to  
  be used as the innermost transport while keeping the full middleware chain intact (signing, retries, status codes, headers, URL prefix, 
  license).
- Added an error when `withSender()` is combined with `withMaxTimeout()`, `viaProxy()`, or `withDebug()`, as these options   
  only apply to the built-in HTTP transport.

## Test plan
- [x] Existing tests pass
- [x] New tests verify the middleware chain is 
  applied when using `withSender()`
- [x] New tests verify an error is raised when conflicting options are combined with `withSender()`