### PR TITLE
reverse-geo error handling and testing updates

### DIFF
--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -41,6 +41,29 @@ class StatusCodeSender implements Sender
         $this->inner = $inner;
     }
 
+    function messageFrom(Response $response, String $fallback)
+    {
+        $payload = $response->getPayload();
+        if ($payload === null || $payload === '') {
+            return $fallback;
+        }
+
+        $responseJSON = json_decode($payload, true, 10);
+
+        if (! isset($responseJSON['errors'])) {
+            return $fallback;
+        }
+
+        $errorMessage = '';
+        foreach ($responseJSON['errors'] as $error) {
+            $errorMessage .= isset($error['message']) ? $error['message'] . ' ' : '';
+        }
+
+        $errorMessage = trim($errorMessage);
+
+        return $errorMessage === '' ? $fallback : $errorMessage;
+    }
+
     function send(Request $request)
     {
         $response = $this->inner->send($request);
@@ -51,17 +74,17 @@ class StatusCodeSender implements Sender
             case 304:
                 throw new RequestNotModifiedException("Record has not been modified since the last request.", $response->getStatusCode(), null, HeaderUtil::extractEtag($response->getHeaders()));
             case 400:
-                throw new BadRequestException("Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.", $response->getStatusCode());
+                throw new BadRequestException($this->messageFrom($response, "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON."), $response->getStatusCode());
             case 401:
-                throw new BadCredentialsException("Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.", $response->getStatusCode());
+                throw new BadCredentialsException($this->messageFrom($response, "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."), $response->getStatusCode());
             case 402:
-                throw new PaymentRequiredException("Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.", $response->getStatusCode());
+                throw new PaymentRequiredException($this->messageFrom($response, "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request."), $response->getStatusCode());
             case 408:
-                throw new RequestTimeoutException("Request timeout error.", $response->getStatusCode());
+                throw new RequestTimeoutException($this->messageFrom($response, "Request timeout error."), $response->getStatusCode());
             case 413:
-                throw new RequestEntityTooLargeException("Request Entity Too Large: The request body has exceeded the maximum size.", $response->getStatusCode());
+                throw new RequestEntityTooLargeException($this->messageFrom($response, "Request Entity Too Large: The request body has exceeded the maximum size."), $response->getStatusCode());
             case 422:
-                throw new UnprocessableEntityException("GET request lacked required fields.", $response->getStatusCode());
+                throw new UnprocessableEntityException($this->messageFrom($response, "GET request lacked required fields."), $response->getStatusCode());
             case 429:
                 $responseJSON = json_decode($response->getPayload(), true, 10);
 

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -13,6 +13,7 @@ use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
 use SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException;
 use SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException;
 use SmartyStreets\PhpSdk\Exceptions\RequestNotModifiedException;
+use SmartyStreets\PhpSdk\Exceptions\RequestTimeoutException;
 use SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException;
 use SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException;
 use SmartyStreets\PhpSdk\Exceptions\UnprocessableEntityException;
@@ -132,11 +133,93 @@ class StatusCodeSenderTest extends TestCase {
         }
     }
 
+    public function test400UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(400, BadRequestException::class);
+    }
+
+    public function test400FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(400, BadRequestException::class,
+            "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.");
+    }
+
+    public function test401UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(401, BadCredentialsException::class);
+    }
+
+    public function test401FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(401, BadCredentialsException::class,
+            "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials.");
+    }
+
+    public function test402UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(402, PaymentRequiredException::class);
+    }
+
+    public function test402FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(402, PaymentRequiredException::class,
+            "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.");
+    }
+
+    public function test408UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(408, RequestTimeoutException::class);
+    }
+
+    public function test408FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(408, RequestTimeoutException::class, "Request timeout error.");
+    }
+
+    public function test413UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(413, RequestEntityTooLargeException::class);
+    }
+
+    public function test413FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(413, RequestEntityTooLargeException::class,
+            "Request Entity Too Large: The request body has exceeded the maximum size.");
+    }
+
+    public function test422UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(422, UnprocessableEntityException::class);
+    }
+
+    public function test422FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(422, UnprocessableEntityException::class, "GET request lacked required fields.");
+    }
+
     private function assertSend($statusCode, $classType) {
         $sender = new StatusCodeSender(new MockStatusCodeSender($statusCode));
 
         $this->expectException($classType);
 
         $sender->send(new Request());
+    }
+
+    private function assertMessageFromPayload($statusCode, $classType) {
+        $payload = json_encode(['errors' => [
+            ['message' => 'First problem.'],
+            ['message' => 'Second problem.'],
+        ]]);
+        $sender = new StatusCodeSender(new MockStatusCodeSender($statusCode, $payload));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (\Exception $ex) {
+            $this->assertInstanceOf($classType, $ex);
+            $this->assertEquals('First problem. Second problem.', $ex->getMessage());
+            $this->assertEquals($statusCode, $ex->getCode());
+        }
+    }
+
+    private function assertFallbackMessage($statusCode, $classType, $fallback) {
+        $sender = new StatusCodeSender(new MockStatusCodeSender($statusCode, ''));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (\Exception $ex) {
+            $this->assertInstanceOf($classType, $ex);
+            $this->assertEquals($fallback, $ex->getMessage());
+            $this->assertEquals($statusCode, $ex->getCode());
+        }
     }
 }


### PR DESCRIPTION
Added a fromMessage function to return either the fallback error message or the readable error from the request. Added testing to check.