### PR TITLE
php group test and version updates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
       "Bash(rm:./*)",
       "Bash(git *)",
       "Bash(make *)",
-      "Bash(phpunit *)",
+      "Bash(./vendor/bin/phpunit *)",
       "Bash(php *)"
     ]
   },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,13 @@ on:
       - '*'
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: php-actions/composer@v6
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --prefer-dist --no-progress
       - run: make test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: php-actions/composer@v6
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+      - run: composer install --prefer-dist --no-progress
       - run: make release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,12 @@ make us_street_api           # Run US Street API examples
 
 To run a single test file:
 ```bash
-phpunit tests/US_Street/ClientTest.php
+./vendor/bin/phpunit tests/US_Street/ClientTest.php
 ```
 
 To run a specific test method:
 ```bash
-phpunit --filter testMethodName tests/US_Street/ClientTest.php
+./vendor/bin/phpunit --filter testMethodName tests/US_Street/ClientTest.php
 ```
 
 ## Architecture Overview
@@ -57,6 +57,6 @@ Tests mirror the src directory structure. Key test utilities in `tests/Mocks/`:
 
 ### Dependencies
 
-- PHP >= 5.6
+- PHP >= 8.3
 - Zero runtime dependencies (PSR Log is optional for custom logging)
-- Dev: PHPUnit 9
+- Dev: PHPUnit 12

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 test:
-	phpunit --exclude-group "integration" tests
+	./vendor/bin/phpunit --exclude-group "integration" tests
 
 test-integration:
 	./tests/run_integration_test.sh

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         }
     ],
     "require": {
-        "php": ">=8.0"
+        "php": ">=8.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^12",
         "psr/log": "^1.0.1"
     },
     "suggest": {

--- a/tests/NativeSenderTest.php
+++ b/tests/NativeSenderTest.php
@@ -81,8 +81,4 @@ class NativeSenderTest extends TestCase {
         $this->assertEquals($expectedBody, $response->getPayload());
         $this->assertEquals(5, count($response->getHeaders()));
     }
-
-    public function testBogusTest() {
-        $this->assertEquals("ok", "ok");
-    }
 }

--- a/tests/NativeSenderTest.php
+++ b/tests/NativeSenderTest.php
@@ -11,91 +11,77 @@ use SmartyStreets\PhpSdk\Request;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Group;
 
+#[Group('integration')]
 class NativeSenderTest extends TestCase {
-//     /**
-//      * @group integration
-//      */
-//     public function testBuildRequestHeaders() {
-//         $request = new Request();
-//         $request->setUrlPrefix("http://localhost:8080");
-//         $customHeaders = [
-//             'vegetable' => 'carrot',
-//             'fruit' => 'banana'
-//         ];
-//
-//         $nativeSender = new NativeSender(10000, null, false, "rivers", $customHeaders);
-//
-//         $refClass = new ReflectionClass($nativeSender);
-//         $buildRequestMethod = $refClass->getMethod('buildRequest');
-//         $buildRequestMethod->setAccessible(true);
-//
-//         $ch = $buildRequestMethod->invoke($nativeSender, $request);
-//         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
-//
-//         curl_exec($ch);
-//         $requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
-//         curl_close($ch);
-//
-//         $this->assertNotFalse($requestHeaders);
-//         $this->assertStringContainsString("vegetable: carrot", $requestHeaders);
-//         $this->assertStringContainsString("fruit: banana", $requestHeaders);
-//         $this->assertStringContainsString("X-Forwarded-For: rivers", $requestHeaders);
-//         $this->assertStringContainsString("User-Agent: smartystreets", $requestHeaders);
-//         $this->assertStringContainsString("Content-Type: application/json", $requestHeaders);
-//         $this->assertStringContainsString("Accept-Encoding: gzip", $requestHeaders);
-//     }
-//
-//     /**
-//      * @group integration
-//      */
-//     public function testBadStatusCode() {
-//         $request = new Request();
-//         $request->setUrlPrefix("http://localhost:8080/EchoServer.php?status=402");
-//
-//         $nativeSender = new NativeSender(10000, null, false);
-//
-//         $response = $nativeSender->send($request);
-//         $status = $response->getStatusCode();
-//         $this->assertEquals("402", $status);
-//     }
-//
-//     /**
-//      * @group integration
-//      */
-//     public function testBadURL() {
-//         $this->expectException(SmartyException::class);
-//         $request = new Request();
-//         $request->setUrlPrefix("http://badserver");
-//
-//         $nativeSender = new NativeSender(10000, null, false);
-//
-//         $response = $nativeSender->send($request);
-//     }
-//
-//     /**
-//      * @group integration
-//      */
-//     public function testGoodResponse() {
-//         $request = new Request();
-//         $request->setUrlPrefix("http://localhost:8080/EchoServer.php");
-//
-//         $nativeSender = new NativeSender(10000, null, false);
-//
-//         $response = $nativeSender->send($request);
-//         $status = $response->getStatusCode();
-//         $this->assertEquals("200", $status);
-//         $expectedBody = <<<EOD
-//         {
-//             "message": "This is a sample message."
-//         }
-//         EOD;
-//         $this->assertEquals($expectedBody, $response->getPayload());
-//         $this->assertEquals(5, count($response->getHeaders()));
-//     }
-//
-    /**
-     * @group integration
-     */
+    public function testBuildRequestHeaders() {
+        $request = new Request();
+        $request->setUrlPrefix("http://localhost:8080");
+        $customHeaders = [
+            'vegetable' => 'carrot',
+            'fruit' => 'banana'
+        ];
+
+        $nativeSender = new NativeSender(10000, null, false, "rivers", $customHeaders);
+
+        $refClass = new ReflectionClass($nativeSender);
+        $buildRequestMethod = $refClass->getMethod('buildRequest');
+        $buildRequestMethod->setAccessible(true);
+
+        $ch = $buildRequestMethod->invoke($nativeSender, $request);
+        curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+
+        curl_exec($ch);
+        $requestHeaders = curl_getinfo($ch, CURLINFO_HEADER_OUT);
+        curl_close($ch);
+
+        $this->assertNotFalse($requestHeaders);
+        $this->assertStringContainsString("vegetable: carrot", $requestHeaders);
+        $this->assertStringContainsString("fruit: banana", $requestHeaders);
+        $this->assertStringContainsString("X-Forwarded-For: rivers", $requestHeaders);
+        $this->assertStringContainsString("User-Agent: smartystreets", $requestHeaders);
+        $this->assertStringContainsString("Content-Type: application/json", $requestHeaders);
+        $this->assertStringContainsString("Accept-Encoding: gzip", $requestHeaders);
+    }
+
+    public function testBadStatusCode() {
+        $request = new Request();
+        $request->setUrlPrefix("http://localhost:8080/EchoServer.php?status=402");
+
+        $nativeSender = new NativeSender(10000, null, false);
+
+        $response = $nativeSender->send($request);
+        $status = $response->getStatusCode();
+        $this->assertEquals("402", $status);
+    }
+
+    public function testBadURL() {
+        $this->expectException(SmartyException::class);
+        $request = new Request();
+        $request->setUrlPrefix("http://badserver");
+
+        $nativeSender = new NativeSender(10000, null, false);
+
+        $response = $nativeSender->send($request);
+    }
+
+    public function testGoodResponse() {
+        $request = new Request();
+        $request->setUrlPrefix("http://localhost:8080/EchoServer.php");
+
+        $nativeSender = new NativeSender(10000, null, false);
+
+        $response = $nativeSender->send($request);
+        $status = $response->getStatusCode();
+        $this->assertEquals("200", $status);
+        $expectedBody = <<<EOD
+        {
+            "message": "This is a sample message."
+        }
+        EOD;
+        $this->assertEquals($expectedBody, $response->getPayload());
+        $this->assertEquals(5, count($response->getHeaders()));
+    }
+
     public function testBogusTest() {
         $this->assertEquals("ok", "ok");
     }

--- a/tests/run_integration_test.sh
+++ b/tests/run_integration_test.sh
@@ -8,7 +8,7 @@ SERVER_PID=$!
 sleep 1
 
 # Run PHPUnit
-phpunit --display-phpunit-deprecations --group integration tests/
+./vendor/bin/phpunit --display-phpunit-deprecations --group integration tests/
 
 # Kill the echo server
 kill $SERVER_PID


### PR DESCRIPTION
- Changed every reference to phpunit to the correct default location composer downloads it to: ./vendor/bin/phpunit
- Changed the integration tests to use the new test group format and uncommented them
- Updated the composer.json and .lock to use the more current versions of php and phpunit for the new test group format
- Changed the github action workflows to use a different step (shivammathur/setup-php not php-actions/composer) so that the runner would use the pinned PHP instead of having different versions used by github and the composer