### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/examples/USEnrichmentEtagExample.php
+++ b/examples/USEnrichmentEtagExample.php
@@ -8,7 +8,6 @@ require_once(__DIR__ . '/../src/US_Enrichment/Business/Detail/Lookup.php');
 
 use SmartyStreets\PhpSdk\BasicAuthCredentials;
 use SmartyStreets\PhpSdk\ClientBuilder;
-use SmartyStreets\PhpSdk\Exceptions\RequestNotModifiedException;
 use SmartyStreets\PhpSdk\US_Enrichment\Business\Detail\Lookup as DetailLookup;
 use SmartyStreets\PhpSdk\US_Enrichment\Business\Summary\Lookup as SummaryLookup;
 
@@ -40,10 +39,12 @@ function exerciseSummaryEtag($client, string $smartyKey): ?string {
     $second->setRequestEtag($captured);
     try {
         $client->sendBusinessLookup($second);
-        echo "  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Results=" . count($second->getResults())
-            . ", Etag=" . display($second->getResponseEtag()) . "\n";
-    } catch (RequestNotModifiedException $ex) {
-        echo "  Call 2 (matching Etag): 304 RequestNotModifiedException — caller treats this as cache-valid. Refreshed Etag=" . display($ex->getResponseEtag()) . "\n";
+        if ($second->getResults() === null) {
+            echo "  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag=" . display($second->getResponseEtag()) . "\n";
+        } else {
+            echo "  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Results=" . count($second->getResults())
+                . ", Etag=" . display($second->getResponseEtag()) . "\n";
+        }
     } catch (Exception $ex) {
         echo "  Call 2 unexpected failure: " . get_class($ex) . ": " . $ex->getMessage() . "\n";
         return null;
@@ -53,10 +54,12 @@ function exerciseSummaryEtag($client, string $smartyKey): ?string {
     $third->setRequestEtag($captured . "X");
     try {
         $client->sendBusinessLookup($third);
-        echo "  Call 3 (mutated Etag): 200 as expected. Results=" . count($third->getResults())
-            . ", Etag=" . display($third->getResponseEtag()) . "\n";
-    } catch (RequestNotModifiedException $ex) {
-        echo "  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.\n";
+        if ($third->getResults() === null) {
+            echo "  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.\n";
+        } else {
+            echo "  Call 3 (mutated Etag): 200 as expected. Results=" . count($third->getResults())
+                . ", Etag=" . display($third->getResponseEtag()) . "\n";
+        }
     } catch (Exception $ex) {
         echo "  Call 3 unexpected failure: " . get_class($ex) . ": " . $ex->getMessage() . "\n";
     }
@@ -89,11 +92,13 @@ function exerciseDetailEtag($client, string $businessId): void {
     $second->setRequestEtag($captured);
     try {
         $client->sendBusinessDetailLookup($second);
-        echo "  Call 2 (matching Etag): 200 — server did NOT honor the conditional. businessId="
-            . ($second->getResult()->businessId ?? '<null>') . ", Etag=" . display($second->getResponseEtag()) . "\n";
-    } catch (RequestNotModifiedException $ex) {
-        echo "  Call 2 (matching Etag): 304 RequestNotModifiedException — caller treats this as cache-valid. Refreshed Etag="
-            . display($ex->getResponseEtag()) . "\n";
+        if ($second->getResult() === null) {
+            echo "  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag="
+                . display($second->getResponseEtag()) . "\n";
+        } else {
+            echo "  Call 2 (matching Etag): 200 — server did NOT honor the conditional. businessId="
+                . ($second->getResult()->businessId ?? '<null>') . ", Etag=" . display($second->getResponseEtag()) . "\n";
+        }
     } catch (Exception $ex) {
         echo "  Call 2 unexpected failure: " . get_class($ex) . ": " . $ex->getMessage() . "\n";
         return;
@@ -103,10 +108,12 @@ function exerciseDetailEtag($client, string $businessId): void {
     $third->setRequestEtag($captured . "X");
     try {
         $client->sendBusinessDetailLookup($third);
-        echo "  Call 3 (mutated Etag): 200 as expected. businessId="
-            . ($third->getResult()->businessId ?? '<null>') . ", Etag=" . display($third->getResponseEtag()) . "\n";
-    } catch (RequestNotModifiedException $ex) {
-        echo "  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.\n";
+        if ($third->getResult() === null) {
+            echo "  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.\n";
+        } else {
+            echo "  Call 3 (mutated Etag): 200 as expected. businessId="
+                . ($third->getResult()->businessId ?? '<null>') . ", Etag=" . display($third->getResponseEtag()) . "\n";
+        }
     } catch (Exception $ex) {
         echo "  Call 3 unexpected failure: " . get_class($ex) . ": " . $ex->getMessage() . "\n";
     }

--- a/src/Exceptions/ForbiddenException.php
+++ b/src/Exceptions/ForbiddenException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SmartyStreets\PhpSdk\Exceptions;
+require_once 'SmartyException.php';
+
+class ForbiddenException extends SmartyException {
+
+}

--- a/src/HeaderUtil.php
+++ b/src/HeaderUtil.php
@@ -14,7 +14,8 @@ class HeaderUtil {
         }
         foreach ($headers as $key => $value) {
             if (is_string($key) && strcasecmp($key, 'etag') === 0) {
-                return is_array($value) ? ($value[0] ?? null) : $value;
+                $etag = is_array($value) ? ($value[0] ?? null) : $value;
+                return $etag === null ? null : trim($etag);
             }
         }
         return null;

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -75,9 +75,8 @@ class StatusCodeSender implements Sender
 
         switch ($response->getStatusCode()) {
             case 200:
-                return $response;
             case 304:
-                throw new RequestNotModifiedException("Not Modified: The requested record has not been modified since the previous request with the Etag value.", $response->getStatusCode(), null, HeaderUtil::extractEtag($response->getHeaders()));
+                return $response;
             case 400:
                 throw new BadRequestException($this->messageFrom($response, "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON."), $response->getStatusCode());
             case 401:

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -48,24 +48,25 @@ class StatusCodeSender implements Sender
     function messageFrom(Response $response, String $fallback)
     {
         $payload = $response->getPayload();
-        if ($payload === null || $payload === '') {
-            return $fallback;
+        $body = $payload === null ? '' : trim($payload);
+
+        if ($body !== '') {
+            $responseJSON = json_decode($payload, true, 10);
+
+            if (isset($responseJSON['errors'])) {
+                $errorMessage = '';
+                foreach ($responseJSON['errors'] as $error) {
+                    $errorMessage .= isset($error['message']) ? $error['message'] . ' ' : '';
+                }
+
+                $errorMessage = trim($errorMessage);
+                if ($errorMessage !== '') {
+                    return $errorMessage;
+                }
+            }
         }
 
-        $responseJSON = json_decode($payload, true, 10);
-
-        if (! isset($responseJSON['errors'])) {
-            return $fallback;
-        }
-
-        $errorMessage = '';
-        foreach ($responseJSON['errors'] as $error) {
-            $errorMessage .= isset($error['message']) ? $error['message'] . ' ' : '';
-        }
-
-        $errorMessage = trim($errorMessage);
-
-        return $errorMessage === '' ? $fallback : $errorMessage;
+        return trim($fallback . ' Body: ' . $body);
     }
 
     function send(Request $request)

--- a/src/StatusCodeSender.php
+++ b/src/StatusCodeSender.php
@@ -5,11 +5,14 @@ namespace SmartyStreets\PhpSdk;
 include_once('Sender.php');
 require_once(__DIR__ . '/HeaderUtil.php');
 require_once(__DIR__ . '/Exceptions/BadCredentialsException.php');
+require_once(__DIR__ . '/Exceptions/BadGatewayException.php');
 require_once(__DIR__ . '/Exceptions/BadRequestException.php');
+require_once(__DIR__ . '/Exceptions/ForbiddenException.php');
 require_once(__DIR__ . '/Exceptions/InternalServerErrorException.php');
 require_once(__DIR__ . '/Exceptions/PaymentRequiredException.php');
 require_once(__DIR__ . '/Exceptions/RequestEntityTooLargeException.php');
 require_once(__DIR__ . '/Exceptions/RequestNotModifiedException.php');
+require_once(__DIR__ . '/Exceptions/RequestTimeoutException.php');
 require_once(__DIR__ . '/Exceptions/ServiceUnavailableException.php');
 require_once(__DIR__ . '/Exceptions/TooManyRequestsException.php');
 require_once(__DIR__ . '/Exceptions/UnprocessableEntityException.php');
@@ -18,6 +21,7 @@ require_once(__DIR__ . '/Exceptions/GatewayTimeoutException.php');
 use SmartyStreets\PhpSdk\Exceptions\BadCredentialsException;
 use SmartyStreets\PhpSdk\Exceptions\BadGatewayException;
 use SmartyStreets\PhpSdk\Exceptions\BadRequestException;
+use SmartyStreets\PhpSdk\Exceptions\ForbiddenException;
 use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
 use SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException;
 use SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException;
@@ -72,13 +76,15 @@ class StatusCodeSender implements Sender
             case 200:
                 return $response;
             case 304:
-                throw new RequestNotModifiedException("Record has not been modified since the last request.", $response->getStatusCode(), null, HeaderUtil::extractEtag($response->getHeaders()));
+                throw new RequestNotModifiedException("Not Modified: The requested record has not been modified since the previous request with the Etag value.", $response->getStatusCode(), null, HeaderUtil::extractEtag($response->getHeaders()));
             case 400:
-                throw new BadRequestException($this->messageFrom($response, "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON."), $response->getStatusCode());
+                throw new BadRequestException($this->messageFrom($response, "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON."), $response->getStatusCode());
             case 401:
                 throw new BadCredentialsException($this->messageFrom($response, "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."), $response->getStatusCode());
             case 402:
                 throw new PaymentRequiredException($this->messageFrom($response, "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request."), $response->getStatusCode());
+            case 403:
+                throw new ForbiddenException($this->messageFrom($response, "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action."), $response->getStatusCode());
             case 408:
                 throw new RequestTimeoutException($this->messageFrom($response, "Request timeout error."), $response->getStatusCode());
             case 413:
@@ -86,32 +92,22 @@ class StatusCodeSender implements Sender
             case 422:
                 throw new UnprocessableEntityException($this->messageFrom($response, "GET request lacked required fields."), $response->getStatusCode());
             case 429:
-                $responseJSON = json_decode($response->getPayload(), true, 10);
-
                 $retryAfterValue = DEFAULT_BACKOFF_DURATION;
                 if (isset($response->getHeaders()['retry-after'])){
                     $retryAfterValue = intval($response->getHeaders()['retry-after']);
                 }
 
-                if (! isset($responseJSON['errors'])) {
-                    throw new TooManyRequestsException("The rate limit for the plan associated with this subscription has been exceeded. To see plans with higher rate limits, visit our pricing page.", $response->getStatusCode(), $retryAfterValue);
-                }
-                $errorMessage = '';
-                foreach($responseJSON['errors'] as $error){
-                    $errorMessage .= isset($error['message']) ? $error['message'].' ': '';
-                }
-
-                throw new TooManyRequestsException($errorMessage, $response->getStatusCode(), $retryAfterValue);
+                throw new TooManyRequestsException($this->messageFrom($response, "Too Many Requests: The rate limit for your account has been exceeded."), $response->getStatusCode(), $retryAfterValue);
             case 500:
-                throw new InternalServerErrorException("Internal Server Error.", $response->getStatusCode());
+                throw new InternalServerErrorException($this->messageFrom($response, "Internal Server Error."), $response->getStatusCode());
             case 502:
-                throw new BadGatewayException("Bad Gateway error.", $response->getStatusCode());
+                throw new BadGatewayException($this->messageFrom($response, "Bad Gateway error."), $response->getStatusCode());
             case 503:
-                throw new ServiceUnavailableException("Service Unavailable. Try again later.", $response->getStatusCode());
+                throw new ServiceUnavailableException($this->messageFrom($response, "Service Unavailable. Try again later."), $response->getStatusCode());
             case 504:
-                throw new GatewayTimeoutException("The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.", $response->getStatusCode());
+                throw new GatewayTimeoutException($this->messageFrom($response, "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed."), $response->getStatusCode());
             default:
-                throw new SmartyException("Error sending request. Status code is: ", $response->getStatusCode());
+                throw new SmartyException($this->messageFrom($response, "The server returned an unexpected HTTP status code: " . $response->getStatusCode()), $response->getStatusCode());
         }
     }
 }

--- a/src/US_Enrichment/Business/Summary/Lookup.php
+++ b/src/US_Enrichment/Business/Summary/Lookup.php
@@ -8,17 +8,17 @@ require_once(__DIR__ . '/Result.php');
 use SmartyStreets\PhpSdk\US_Enrichment\Lookup as EnrichmentLookup;
 
 class Lookup extends EnrichmentLookup {
-    /** @var Result[] */
-    private array $results = [];
+    /** @var Result[]|null */
+    private ?array $results = null;
 
     public function __construct(?string $smartyKey = null) {
         parent::__construct($smartyKey, 'business', null);
     }
 
     /**
-     * @return Result[]
+     * @return Result[]|null Null when the record was not modified (304) or no request has been sent.
      */
-    public function getResults(): array {
+    public function getResults(): ?array {
         return $this->results;
     }
 

--- a/src/US_Enrichment/Client.php
+++ b/src/US_Enrichment/Client.php
@@ -55,7 +55,7 @@ class Client {
      * @param BusinessSummaryLookup|string|null $businessLookup SmartyKey string or a Business\Summary\Lookup.
      * @return \SmartyStreets\PhpSdk\US_Enrichment\Business\Summary\Result[]
      */
-    public function sendBusinessLookup($businessLookup): array {
+    public function sendBusinessLookup($businessLookup): ?array {
         if (is_string($businessLookup)) {
             $lookup = new BusinessSummaryLookup($businessLookup);
         } elseif ($businessLookup instanceof BusinessSummaryLookup) {
@@ -125,6 +125,9 @@ class Client {
         $etag = HeaderUtil::extractEtag($response->getHeaders());
         if ($etag !== null) {
             $lookup->setResponseEtag($etag);
+        }
+        if ($response->getStatusCode() === 304) {
+            return;
         }
         $payload = $response->getPayload();
         $decoded = $payload === null || $payload === '' ? null : $this->serializer->deserialize($payload);

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -223,7 +223,7 @@ class StatusCodeSenderTest extends TestCase {
             $sender->send(new Request());
             $this->fail("Should have thrown exception.");
         } catch (TooManyRequestsException $ex) {
-            $this->assertEquals("Too Many Requests: The rate limit for your account has been exceeded.", $ex->getMessage());
+            $this->assertEquals("Too Many Requests: The rate limit for your account has been exceeded. Body:", $ex->getMessage());
         }
     }
 
@@ -280,6 +280,40 @@ class StatusCodeSenderTest extends TestCase {
             "The server returned an unexpected HTTP status code: 418");
     }
 
+    public function testFallbackAppendsUnparseableBody() {
+        $sender = new StatusCodeSender(new MockStatusCodeSender(422, 'not json'));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (UnprocessableEntityException $ex) {
+            $this->assertEquals("GET request lacked required fields. Body: not json", $ex->getMessage());
+        }
+    }
+
+    public function testFallbackAppendsBodyWithoutMessages() {
+        $payload = json_encode(['errors' => []]);
+        $sender = new StatusCodeSender(new MockStatusCodeSender(422, $payload));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (UnprocessableEntityException $ex) {
+            $this->assertEquals("GET request lacked required fields. Body: " . $payload, $ex->getMessage());
+        }
+    }
+
+    public function testBlankBodyYieldsEmptyBodyLabel() {
+        $sender = new StatusCodeSender(new MockStatusCodeSender(422, '   '));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (UnprocessableEntityException $ex) {
+            $this->assertEquals("GET request lacked required fields. Body:", $ex->getMessage());
+        }
+    }
+
     private function assertSend($statusCode, $classType) {
         $sender = new StatusCodeSender(new MockStatusCodeSender($statusCode));
 
@@ -313,7 +347,7 @@ class StatusCodeSenderTest extends TestCase {
             $this->fail("Should have thrown exception.");
         } catch (\Exception $ex) {
             $this->assertInstanceOf($classType, $ex);
-            $this->assertEquals($fallback, $ex->getMessage());
+            $this->assertEquals($fallback . " Body:", $ex->getMessage());
             $this->assertEquals($statusCode, $ex->getCode());
         }
     }

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -7,7 +7,9 @@ require_once(dirname(dirname(__FILE__)) . '/src/StatusCodeSender.php');
 require_once(dirname(dirname(__FILE__)) . '/src/Request.php');
 
 use SmartyStreets\PhpSdk\Exceptions\BadCredentialsException;
+use SmartyStreets\PhpSdk\Exceptions\BadGatewayException;
 use SmartyStreets\PhpSdk\Exceptions\BadRequestException;
+use SmartyStreets\PhpSdk\Exceptions\ForbiddenException;
 use SmartyStreets\PhpSdk\Exceptions\GatewayTimeoutException;
 use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
 use SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException;
@@ -15,6 +17,7 @@ use SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException;
 use SmartyStreets\PhpSdk\Exceptions\RequestNotModifiedException;
 use SmartyStreets\PhpSdk\Exceptions\RequestTimeoutException;
 use SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException;
+use SmartyStreets\PhpSdk\Exceptions\SmartyException;
 use SmartyStreets\PhpSdk\Exceptions\TooManyRequestsException;
 use SmartyStreets\PhpSdk\Exceptions\UnprocessableEntityException;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockStatusCodeSender;
@@ -139,7 +142,7 @@ class StatusCodeSenderTest extends TestCase {
 
     public function test400FallsBackToDefaultMessage() {
         $this->assertFallbackMessage(400, BadRequestException::class,
-            "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.");
+            "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.");
     }
 
     public function test401UsesMessageFromResponsePayload() {
@@ -183,6 +186,98 @@ class StatusCodeSenderTest extends TestCase {
 
     public function test422FallsBackToDefaultMessage() {
         $this->assertFallbackMessage(422, UnprocessableEntityException::class, "GET request lacked required fields.");
+    }
+
+    public function test403ResponseThrowsForbiddenException() {
+        $this->assertSend(403, ForbiddenException::class);
+    }
+
+    public function test403UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(403, ForbiddenException::class);
+    }
+
+    public function test403FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(403, ForbiddenException::class,
+            "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.");
+    }
+
+    public function test429UsesMessageFromResponsePayload() {
+        $payload = json_encode(['errors' => [
+            ['message' => 'First problem.'],
+            ['message' => 'Second problem.'],
+        ]]);
+        $sender = new StatusCodeSender(new MockStatusCodeSender(429, $payload));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (TooManyRequestsException $ex) {
+            $this->assertEquals('First problem. Second problem.', $ex->getMessage());
+        }
+    }
+
+    public function test429FallsBackToDefaultMessage() {
+        $sender = new StatusCodeSender(new MockStatusCodeSender(429, ''));
+
+        try {
+            $sender->send(new Request());
+            $this->fail("Should have thrown exception.");
+        } catch (TooManyRequestsException $ex) {
+            $this->assertEquals("Too Many Requests: The rate limit for your account has been exceeded.", $ex->getMessage());
+        }
+    }
+
+    public function test500UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(500, InternalServerErrorException::class);
+    }
+
+    public function test500FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(500, InternalServerErrorException::class, "Internal Server Error.");
+    }
+
+    public function test502UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(502, BadGatewayException::class);
+    }
+
+    public function test502FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(502, BadGatewayException::class, "Bad Gateway error.");
+    }
+
+    public function test503UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(503, ServiceUnavailableException::class);
+    }
+
+    public function test503FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(503, ServiceUnavailableException::class, "Service Unavailable. Try again later.");
+    }
+
+    public function test504UsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(504, GatewayTimeoutException::class);
+    }
+
+    public function test504FallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(504, GatewayTimeoutException::class,
+            "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.");
+    }
+
+    public function test304UsesStandardMessage() {
+        $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', null));
+        try {
+            $sender->send(new Request());
+            $this->fail("Expected RequestNotModifiedException");
+        } catch (RequestNotModifiedException $ex) {
+            $this->assertEquals("Not Modified: The requested record has not been modified since the previous request with the Etag value.",
+                $ex->getMessage());
+        }
+    }
+
+    public function testUnexpectedStatusCodeUsesMessageFromResponsePayload() {
+        $this->assertMessageFromPayload(418, SmartyException::class);
+    }
+
+    public function testUnexpectedStatusCodeFallsBackToDefaultMessage() {
+        $this->assertFallbackMessage(418, SmartyException::class,
+            "The server returned an unexpected HTTP status code: 418");
     }
 
     private function assertSend($statusCode, $classType) {

--- a/tests/StatusCodeSenderTest.php
+++ b/tests/StatusCodeSenderTest.php
@@ -14,7 +14,6 @@ use SmartyStreets\PhpSdk\Exceptions\GatewayTimeoutException;
 use SmartyStreets\PhpSdk\Exceptions\InternalServerErrorException;
 use SmartyStreets\PhpSdk\Exceptions\PaymentRequiredException;
 use SmartyStreets\PhpSdk\Exceptions\RequestEntityTooLargeException;
-use SmartyStreets\PhpSdk\Exceptions\RequestNotModifiedException;
 use SmartyStreets\PhpSdk\Exceptions\RequestTimeoutException;
 use SmartyStreets\PhpSdk\Exceptions\ServiceUnavailableException;
 use SmartyStreets\PhpSdk\Exceptions\SmartyException;
@@ -106,34 +105,13 @@ class StatusCodeSenderTest extends TestCase {
         $this->assertSend(504, $classType);
     }
 
-    public function testNotModifiedExceptionCarriesResponseEtag() {
+    public function test304IsNotAnError() {
         $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', ['Etag' => 'server-refreshed-etag']));
-        try {
-            $sender->send(new Request());
-            $this->fail("Expected RequestNotModifiedException");
-        } catch (RequestNotModifiedException $ex) {
-            $this->assertEquals('server-refreshed-etag', $ex->getResponseEtag());
-        }
-    }
 
-    public function testNotModifiedExceptionResponseEtagIsCaseInsensitive() {
-        $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', ['ETAG' => 'case-insensitive-etag']));
-        try {
-            $sender->send(new Request());
-            $this->fail("Expected RequestNotModifiedException");
-        } catch (RequestNotModifiedException $ex) {
-            $this->assertEquals('case-insensitive-etag', $ex->getResponseEtag());
-        }
-    }
+        $response = $sender->send(new Request());
 
-    public function testNotModifiedExceptionResponseEtagNullWhenHeaderAbsent() {
-        $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', null));
-        try {
-            $sender->send(new Request());
-            $this->fail("Expected RequestNotModifiedException");
-        } catch (RequestNotModifiedException $ex) {
-            $this->assertNull($ex->getResponseEtag());
-        }
+        $this->assertEquals(304, $response->getStatusCode());
+        $this->assertEquals('server-refreshed-etag', $response->getHeaders()['Etag']);
     }
 
     public function test400UsesMessageFromResponsePayload() {
@@ -258,17 +236,6 @@ class StatusCodeSenderTest extends TestCase {
     public function test504FallsBackToDefaultMessage() {
         $this->assertFallbackMessage(504, GatewayTimeoutException::class,
             "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.");
-    }
-
-    public function test304UsesStandardMessage() {
-        $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', null));
-        try {
-            $sender->send(new Request());
-            $this->fail("Expected RequestNotModifiedException");
-        } catch (RequestNotModifiedException $ex) {
-            $this->assertEquals("Not Modified: The requested record has not been modified since the previous request with the Etag value.",
-                $ex->getMessage());
-        }
     }
 
     public function testUnexpectedStatusCodeUsesMessageFromResponsePayload() {

--- a/tests/US_Enrichment/BusinessClientTest.php
+++ b/tests/US_Enrichment/BusinessClientTest.php
@@ -9,6 +9,8 @@ require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Enrichment/Client.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Enrichment/Business/Summary/Lookup.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Enrichment/Business/Detail/Lookup.php');
+require_once(dirname(dirname(dirname(__FILE__))) . '/src/StatusCodeSender.php');
+require_once(dirname(dirname(__FILE__)) . '/Mocks/MockStatusCodeSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/URLPrefixSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/Response.php');
 
@@ -19,6 +21,8 @@ use SmartyStreets\PhpSdk\Tests\Mocks\MockDeserializer;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockSender;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockSerializer;
 use SmartyStreets\PhpSdk\Tests\Mocks\RequestCapturingSender;
+use SmartyStreets\PhpSdk\StatusCodeSender;
+use SmartyStreets\PhpSdk\Tests\Mocks\MockStatusCodeSender;
 use SmartyStreets\PhpSdk\URLPrefixSender;
 use SmartyStreets\PhpSdk\US_Enrichment\Business\Detail\Lookup as DetailLookup;
 use SmartyStreets\PhpSdk\US_Enrichment\Business\Summary\Lookup as SummaryLookup;
@@ -360,6 +364,19 @@ class BusinessClientTest extends TestCase {
         $result = $client->sendBusinessDetailLookup("ABC");
 
         $this->assertNull($result);
+    }
+
+    public function testSummary304LeavesResultsNullForCacheHitDetection() {
+        $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', ['Etag' => 'refreshed-etag']));
+        $client = new Client($sender, new MockDeserializer(null));
+        $lookup = new SummaryLookup("1962995076");
+        $lookup->setRequestEtag('old-etag');
+
+        $results = $client->sendBusinessLookup($lookup);
+
+        $this->assertNull($results);
+        $this->assertNull($lookup->getResults());
+        $this->assertEquals('refreshed-etag', $lookup->getResponseEtag());
     }
 
     // endregion

--- a/tests/US_Enrichment/ClientTest.php
+++ b/tests/US_Enrichment/ClientTest.php
@@ -6,6 +6,7 @@ require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSerializer.php');
 require_once(dirname(dirname(__FILE__)) . '/Mocks/MockDeserializer.php');
 require_once(dirname(dirname(__FILE__)) . '/Mocks/RequestCapturingSender.php');
 require_once(dirname(dirname(__FILE__)) . '/Mocks/MockStatusCodeSender.php');
+require_once(dirname(dirname(dirname(__FILE__))) . '/src/StatusCodeSender.php');
 require_once(dirname(dirname(__FILE__)) . '/Mocks/MockSender.php');
 require_once(dirname(dirname(__FILE__)) . '/Mocks/MockCrashingSender.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/src/US_Enrichment/Client.php');
@@ -16,6 +17,8 @@ use SmartyStreets\PhpSdk\Tests\Mocks\MockSerializer;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockDeserializer;
 use SmartyStreets\PhpSdk\Tests\Mocks\MockSender;
 use SmartyStreets\PhpSdk\Tests\Mocks\RequestCapturingSender;
+use SmartyStreets\PhpSdk\StatusCodeSender;
+use SmartyStreets\PhpSdk\Tests\Mocks\MockStatusCodeSender;
 use SmartyStreets\PhpSdk\URLPrefixSender;
 use SmartyStreets\PhpSdk\Response;
 use SmartyStreets\PhpSdk\US_Enrichment\Client;
@@ -112,6 +115,21 @@ class ClientTest extends TestCase {
         $this->assertEquals("abcdef", $lookup->getResponseEtag());
     }
 
+    public function testResponseEtagIsTrimmed() {
+        $mockHeaders = [
+            'etag' => ' abcdef'
+        ];
+        $response = new Response(200, "hello world", $mockHeaders);
+        $sender = new URLPrefixSender("http://localhost", new MockSender($response));
+        $client = new Client($sender, new MockDeserializer([['count' => '5']]));
+        $lookup = new Lookup();
+        $lookup->setFreeform("123 Test Street City State Zipcode");
+
+        $client->sendPropertyPrincipalLookup($lookup);
+
+        $this->assertEquals("abcdef", $lookup->getResponseEtag());
+    }
+
     public function testRequestEtagHeaderIsSent() {
         $capturingSender = new RequestCapturingSender();
         $sender = new URLPrefixSender("http://localhost", $capturingSender);
@@ -150,5 +168,19 @@ class ClientTest extends TestCase {
         $client = new Client(new URLPrefixSender("http://localhost", new RequestCapturingSender()), new MockSerializer(null));
         $this->expectException(\SmartyStreets\PhpSdk\Exceptions\SmartyException::class);
         $client->sendGeoReferenceLookup(42);
+    }
+
+    public function test304IsSuccessWithRefreshedEtagAndUntouchedResults() {
+        $sender = new StatusCodeSender(new MockStatusCodeSender(304, '', ['Etag' => 'refreshed-etag']));
+        $client = new Client($sender, new MockDeserializer(null));
+        $lookup = new Lookup();
+        $lookup->setFreeform("123 Test Street City State Zipcode");
+        $lookup->setRequestEtag('old-etag');
+        $lookup->setResponse(['prior']);
+
+        $client->sendPropertyPrincipalLookup($lookup);
+
+        $this->assertEquals('refreshed-etag', $lookup->getResponseEtag());
+        $this->assertEquals(['prior'], $lookup->getResponse());
     }
 }


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- Added `403` -> new `ForbiddenException`; 429/5xx/default now extract the API message too.
- Standardized 304/400/429/unexpected-status wording.

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
